### PR TITLE
[Feat] 지도를 사용한 CommunityCenter 위치 기능 개발

### DIFF
--- a/src/main/java/com/save_help/Save_Help/communityCenter/controller/CommunityCenterController.java
+++ b/src/main/java/com/save_help/Save_Help/communityCenter/controller/CommunityCenterController.java
@@ -35,7 +35,7 @@ public class CommunityCenterController {
     }
 
     @Operation(summary = "센터 생성", description = "센터를 생성합니다")
-    @PostMapping
+    @PostMapping("/create")
     public ResponseEntity<CommunityCenter> createCenter(@RequestBody CommunityCenterDto dto) {
         return ResponseEntity.ok(service.createCenter(dto));
     }
@@ -69,5 +69,26 @@ public class CommunityCenterController {
     @GetMapping("/active/type/{type}")
     public ResponseEntity<List<CommunityCenter>> getActiveCentersByType(@PathVariable CenterType type) {
         return ResponseEntity.ok(service.getActiveCentersByType(type));
+    }
+
+    @PostMapping
+    public ResponseEntity<CommunityCenter> registerCenter(@RequestBody CommunityCenter center) {
+        CommunityCenter saved = service.registerCenter(center);
+        return ResponseEntity.ok(saved);
+    }
+
+
+     // 센터 타입별 + 반경 내 검색
+     // 예: /api/community-centers/nearby/type?lat=37.498&lng=127.027&type=HOSPITAL&radiusKm=5
+
+    @GetMapping("/nearby/type")
+    public ResponseEntity<List<CommunityCenter>> getCentersNearLocationByType(
+            @RequestParam double lat,
+            @RequestParam double lng,
+            @RequestParam CenterType type,
+            @RequestParam(defaultValue = "5.0") double radiusKm) {
+        List<CommunityCenter> centers =
+                service.findCentersNearLocationByType(lat, lng, radiusKm, type);
+        return ResponseEntity.ok(centers);
     }
 }

--- a/src/main/java/com/save_help/Save_Help/communityCenter/repository/CommunityCenterRepository.java
+++ b/src/main/java/com/save_help/Save_Help/communityCenter/repository/CommunityCenterRepository.java
@@ -19,4 +19,5 @@ public interface CommunityCenterRepository extends JpaRepository<CommunityCenter
     List<CommunityCenter> findByActiveTrue();
 
     List<CommunityCenter> findByTypeAndActiveTrue(CenterType type);
+
 }

--- a/src/main/java/com/save_help/Save_Help/communityCenter/service/CommunityCenterService.java
+++ b/src/main/java/com/save_help/Save_Help/communityCenter/service/CommunityCenterService.java
@@ -4,10 +4,22 @@ import com.save_help.Save_Help.communityCenter.dto.CommunityCenterDto;
 import com.save_help.Save_Help.communityCenter.entity.CenterType;
 import com.save_help.Save_Help.communityCenter.entity.CommunityCenter;
 import com.save_help.Save_Help.communityCenter.repository.CommunityCenterRepository;
+import com.save_help.Save_Help.map.KakaoMapService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriUtils;
 
+
+import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Service
@@ -15,6 +27,8 @@ import java.util.Optional;
 public class CommunityCenterService {
 
     private final CommunityCenterRepository repository;
+    private final KakaoMapService kakaoMapService;
+
 
     public List<CommunityCenter> getAllCenters() {
         return repository.findAll();
@@ -63,4 +77,42 @@ public class CommunityCenterService {
     public List<CommunityCenter> getActiveCentersByType(CenterType type) {
         return repository.findByTypeAndActiveTrue(type);
     }
+
+
+
+
+    public CommunityCenter registerCenter(CommunityCenter center) {
+        // 1. 센터 이름으로 위도/경도 자동 조회
+        double[] coordinates = kakaoMapService.getCoordinatesByName(center.getName());
+        center.setLatitude(coordinates[0]);
+        center.setLongitude(coordinates[1]);
+
+        // 2️. 저장
+        return repository.save(center);
+    }
+
+     // 거리 계산 (Haversine 공식)
+    private double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
+        final int R = 6371; // km
+        double latDistance = Math.toRadians(lat2 - lat1);
+        double lonDistance = Math.toRadians(lon2 - lon1);
+        double a = Math.sin(latDistance / 2) * Math.sin(latDistance / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(lonDistance / 2) * Math.sin(lonDistance / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return R * c;
+    }
+
+    //특정 타입의 센터 중 주어진 좌표 기준 반경 내 센터 목록 조회
+    public List<CommunityCenter> findCentersNearLocationByType(double userLat, double userLng, double radiusKm, CenterType type) {
+        List<CommunityCenter> centers = repository.findByTypeAndActiveTrue(type);
+
+        return centers.stream()
+                .filter(c -> c.getLatitude() != null && c.getLongitude() != null)
+                .filter(c -> calculateDistance(userLat, userLng, c.getLatitude(), c.getLongitude()) <= radiusKm)
+                .sorted(Comparator.comparingDouble(c ->
+                        calculateDistance(userLat, userLng, c.getLatitude(), c.getLongitude())))
+                .toList();
+    }
+
 }

--- a/src/main/java/com/save_help/Save_Help/map/KakaoMapService.java
+++ b/src/main/java/com/save_help/Save_Help/map/KakaoMapService.java
@@ -1,0 +1,50 @@
+package com.save_help.Save_Help.map;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoMapService {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    @Value("${kakao.api-key}")
+    private String REST_API_KEY;
+    /**
+     * 센터 이름(또는 주소)으로 위도, 경도 좌표 조회
+     */
+    public double[] getCoordinatesByName(String name) {
+        String url = "https://dapi.kakao.com/v2/local/search/keyword.json?query=" +
+                UriUtils.encode(name, StandardCharsets.UTF_8);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", REST_API_KEY);
+
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+        ResponseEntity<Map> response = restTemplate.exchange(url, HttpMethod.GET, entity, Map.class);
+
+        List<Map<String, Object>> documents = (List<Map<String, Object>>) response.getBody().get("documents");
+
+        if (documents == null || documents.isEmpty()) {
+            throw new IllegalArgumentException("해당 이름으로 위치를 찾을 수 없습니다: " + name);
+        }
+
+        Map<String, Object> doc = documents.get(0);
+        double longitude = Double.parseDouble((String) doc.get("x")); // 경도
+        double latitude = Double.parseDouble((String) doc.get("y"));  // 위도
+
+        return new double[]{latitude, longitude};
+    }
+
+}


### PR DESCRIPTION
## 📌[Feat] 지도를 사용한 CommunityCenter 위치 기능 개발

---

## ✨ 작업 개요
- KAKAO MAP API를 사용한 CommunityCenter의 위치를 불러오는 기능을 개발하였습니다.
- 공공데이터 API를 사용하여 CommunityCenter의 정확한 위도, 경도 값을 사용할 예정입니다.
- 프론트를 연동할 때, 지도 API를 활용해서 센터들의 위치를 마크하는 기능을 개발할 예정입니다.
---

## 🔨 변경 사항

---

## ✅ 체크리스트
- [x] 카카오 디벨로퍼스 REST API KEY 발급
- [x] 센터 이름(또는 주소)으로 위도, 경도 좌표 조회 기능 개발
- [x] 특정 타입의 센터만 반경 내에서 검색하는 기능 개발
- [x] 사용자와 센터 거리 계산 기능 개발
- [x] 센터 타입별 가장 가까운 센터 찾기 기능 개발
- [x] 공공데이터를 사용한 센터 실제 센터명, 주소 도입 예정
- [x] 프론트 연동 시 지도에 센터들의 위치를 마크하는 기능 개발 예정


---

## 📷 스크린샷 (선택)
<!-- UI 작업 시 스크린샷이나 API 응답 예시를 첨부하면 좋아요 -->

---

## 🔗 관련 이슈
<!-- 관련된 이슈 번호가 있다면 적어주세요 -->
- close #이슈번호