### PR TITLE
[Feat] 생필품 메시지 기능 개발

### DIFF
--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/dto/DailyNecessitiesCenterMessageDto.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/dto/DailyNecessitiesCenterMessageDto.java
@@ -1,0 +1,32 @@
+package com.save_help.Save_Help.dailyNecessities.dto;
+
+import com.save_help.Save_Help.dailyNecessities.entity.DailyNecessitiesCenterMessage;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DailyNecessitiesCenterMessageDto {
+    private Long id;
+    private Long centerId;
+    private Long userId;
+    private String message;
+    private LocalDateTime sentAt;
+    private boolean read;
+
+    public static DailyNecessitiesCenterMessageDto fromEntity(DailyNecessitiesCenterMessage msg) {
+        return DailyNecessitiesCenterMessageDto.builder()
+                .id(msg.getId())
+                .centerId(msg.getCenter().getId())
+                .userId(msg.getUser().getId())
+                .message(msg.getMessage())
+                .sentAt(msg.getSentAt())
+                .read(msg.isRead())
+                .build();
+    }
+
+}

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/dto/DailyNecessitiesUserRequestMessageDto.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/dto/DailyNecessitiesUserRequestMessageDto.java
@@ -1,0 +1,32 @@
+package com.save_help.Save_Help.dailyNecessities.dto;
+
+import com.save_help.Save_Help.dailyNecessities.entity.DailyNecessitiesUserRequestMessage;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DailyNecessitiesUserRequestMessageDto {
+
+    private Long id;
+    private Long userId;
+    private Long centerId;
+    private String message;
+    private LocalDateTime sentAt;
+    private boolean processed;
+
+    public static DailyNecessitiesUserRequestMessageDto fromEntity(DailyNecessitiesUserRequestMessage entity) {
+        return DailyNecessitiesUserRequestMessageDto.builder()
+                .id(entity.getId())
+                .userId(entity.getUser().getId())
+                .centerId(entity.getCenter().getId())
+                .message(entity.getMessage())
+                .sentAt(entity.getSentAt())
+                .processed(entity.isProcessed())
+                .build();
+    }
+}

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessitiesCenterMessage.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessitiesCenterMessage.java
@@ -1,0 +1,36 @@
+package com.save_help.Save_Help.dailyNecessities.entity;
+
+import com.save_help.Save_Help.communityCenter.entity.CommunityCenter;
+import com.save_help.Save_Help.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DailyNecessitiesCenterMessage  {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "center_id")
+    private CommunityCenter center;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(length = 500)
+    private String message;
+
+    private LocalDateTime sentAt = LocalDateTime.now();
+
+    private boolean read = false; // 읽음 여부
+}

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessitiesUserRequestMessage.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessitiesUserRequestMessage.java
@@ -1,0 +1,37 @@
+package com.save_help.Save_Help.dailyNecessities.entity;
+
+import com.save_help.Save_Help.user.entity.User;
+import com.save_help.Save_Help.communityCenter.entity.CommunityCenter;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DailyNecessitiesUserRequestMessage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 요청한 사용자
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    // 요청할 센터
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "center_id")
+    private CommunityCenter center;
+
+    @Column(length = 500)
+    private String message; // 요청 내용 (품목명, 수량 등)
+
+    private LocalDateTime sentAt = LocalDateTime.now();
+
+    private boolean processed = false; // 센터 처리 여부
+}

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesCenterMessageRepository.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesCenterMessageRepository.java
@@ -1,0 +1,10 @@
+package com.save_help.Save_Help.dailyNecessities.repository;
+
+import com.save_help.Save_Help.dailyNecessities.entity.DailyNecessitiesCenterMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface DailyNecessitiesCenterMessageRepository extends JpaRepository<DailyNecessitiesCenterMessage, Long> {
+    List<DailyNecessitiesCenterMessage> findByUserIdOrderBySentAtDesc(Long userId);
+}

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesUserRequestMessageRepository.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesUserRequestMessageRepository.java
@@ -1,0 +1,13 @@
+package com.save_help.Save_Help.dailyNecessities.repository;
+
+import com.save_help.Save_Help.dailyNecessities.entity.DailyNecessities;
+import com.save_help.Save_Help.dailyNecessities.entity.DailyNecessitiesUserRequestMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface DailyNecessitiesUserRequestMessageRepository extends JpaRepository<DailyNecessitiesUserRequestMessage, Long> {
+
+    List<DailyNecessitiesUserRequestMessage> findByCenterIdOrderBySentAtDesc(Long centerId);
+    List<DailyNecessitiesUserRequestMessage> findByUserIdOrderBySentAtDesc(Long userId);
+}

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/service/DailyNecessitiesCenterMessageService.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/service/DailyNecessitiesCenterMessageService.java
@@ -1,0 +1,54 @@
+package com.save_help.Save_Help.dailyNecessities.service;
+
+
+import com.save_help.Save_Help.communityCenter.repository.CommunityCenterRepository;
+import com.save_help.Save_Help.dailyNecessities.dto.DailyNecessitiesCenterMessageDto;
+import com.save_help.Save_Help.dailyNecessities.entity.DailyNecessitiesCenterMessage;
+import com.save_help.Save_Help.dailyNecessities.repository.DailyNecessitiesCenterMessageRepository;
+import com.save_help.Save_Help.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class DailyNecessitiesCenterMessageService {
+
+    private final DailyNecessitiesCenterMessageRepository messageRepository;
+    private final CommunityCenterRepository centerRepository;
+    private final UserRepository userRepository;
+
+    // 메시지 전송
+    public DailyNecessitiesCenterMessageDto sendMessage(Long centerId, Long userId, String message) {
+        var center = centerRepository.findById(centerId)
+                .orElseThrow(() -> new IllegalArgumentException("센터가 존재하지 않습니다."));
+        var user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다."));
+
+        DailyNecessitiesCenterMessage msg = DailyNecessitiesCenterMessage.builder()
+                .center(center)
+                .user(user)
+                .message(message)
+                .build();
+
+        return DailyNecessitiesCenterMessageDto.fromEntity(messageRepository.save(msg));
+    }
+
+    // 사용자 메시지 조회
+    public List<DailyNecessitiesCenterMessageDto> getMessagesForUser(Long userId) {
+        return messageRepository.findByUserIdOrderBySentAtDesc(userId)
+                .stream()
+                .map(DailyNecessitiesCenterMessageDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    // 메시지 읽음 처리
+    public void markAsRead(Long messageId) {
+        var msg = messageRepository.findById(messageId)
+                .orElseThrow(() -> new IllegalArgumentException("메시지가 존재하지 않습니다."));
+        msg.setRead(true);
+        messageRepository.save(msg);
+    }
+}

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/service/DailyNecessitiesUserRequestMessageService.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/service/DailyNecessitiesUserRequestMessageService.java
@@ -1,0 +1,59 @@
+package com.save_help.Save_Help.dailyNecessities.service;
+
+
+import com.save_help.Save_Help.communityCenter.repository.CommunityCenterRepository;
+import com.save_help.Save_Help.dailyNecessities.dto.DailyNecessitiesUserRequestMessageDto;
+import com.save_help.Save_Help.dailyNecessities.entity.DailyNecessitiesUserRequestMessage;
+import com.save_help.Save_Help.dailyNecessities.repository.DailyNecessitiesUserRequestMessageRepository;
+import com.save_help.Save_Help.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class DailyNecessitiesUserRequestMessageService {
+
+    private final DailyNecessitiesUserRequestMessageRepository repository;
+    private final UserRepository userRepository;
+    private final CommunityCenterRepository centerRepository;
+
+    // 사용자 요청 생성
+    public DailyNecessitiesUserRequestMessageDto create(Long userId, Long centerId, String message) {
+        var user = userRepository.findById(userId).orElseThrow();
+        var center = centerRepository.findById(centerId).orElseThrow();
+
+        DailyNecessitiesUserRequestMessage request = DailyNecessitiesUserRequestMessage.builder()
+                .user(user)
+                .center(center)
+                .message(message)
+                .build();
+
+        return DailyNecessitiesUserRequestMessageDto.fromEntity(repository.save(request));
+    }
+
+    // 특정 센터가 받은 요청 조회
+    public List<DailyNecessitiesUserRequestMessageDto> getRequestsForCenter(Long centerId) {
+        return repository.findByCenterIdOrderBySentAtDesc(centerId)
+                .stream()
+                .map(DailyNecessitiesUserRequestMessageDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    // 특정 사용자가 보낸 요청 조회
+    public List<DailyNecessitiesUserRequestMessageDto> getRequestsByUser(Long userId) {
+        return repository.findByUserIdOrderBySentAtDesc(userId)
+                .stream()
+                .map(DailyNecessitiesUserRequestMessageDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    // 요청 처리 상태 변경
+    public void markAsProcessed(Long requestId) {
+        var request = repository.findById(requestId).orElseThrow();
+        request.setProcessed(true);
+        repository.save(request);
+    }
+}


### PR DESCRIPTION
## 📌 [Feat] 생필품 메시지 기능 개발


---

## ✨ 작업 개요
- 커뮤니티 센터나 생필품 지원처에서 사용자에게 생필품 전달 메시지를 주는 기능을 개발하였습니다.
- 사용자가 커뮤니티 센터나 생필품 지원처에 생필품 요청 메시지를 보내는 기능을 개발하였습니다.
- MMS와 같은 외부 메시징 API(Twilio SMS 등 연동)를 사용할 예정입니다.

---

## 🔨 변경 사항

---

## ✅ 체크리스트
- [x] 생필품 전달 메시지 기능 개발
- [x] 사용자 메시지 조회 기능 개발
- [x] 메시지 읽음 처리 기능 개발
- [x] 사용자가 센터에 필요한 생필품을 요청하는 메시지 생성 기능 개발
- [x] 센터가 받은 요청 조회 기능 개발
- [x] 사용자가 보낸 요청 조회 기능 개발
- [x] 외부 메시징 API 도입 예정


---

## 📷 스크린샷 (선택)
<!-- UI 작업 시 스크린샷이나 API 응답 예시를 첨부하면 좋아요 -->

---

## 🔗 관련 이슈
<!-- 관련된 이슈 번호가 있다면 적어주세요 -->
- close #이슈번호