### PR TITLE
[Feat] 생필품 자동 재고 예측 및 발주 제안 기능 개발

### DIFF
--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/controller/DailyNecessitiesController.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/controller/DailyNecessitiesController.java
@@ -22,6 +22,9 @@ public class DailyNecessitiesController {
     private final DailyNecessitiesDonationService donationService;
     private final DailyNecessitiesCenterMessageService messageService;
     private final DailyNecessitiesUserRequestMessageService userRequestMessageService;
+    private final DailyNecessitiesRestockForecastService restockForecastService;
+
+
 
     public DailyNecessitiesController(
             DailyNecessitiesService necessitiesService,
@@ -29,7 +32,7 @@ public class DailyNecessitiesController {
             DailyNecessitiesStockService stockService,
             DailyNecessitiesStatisticsService statisticsService,
             DailyNecessitiesReportService reportService,
-            DailyNecessitiesDonationService donationService, DailyNecessitiesCenterMessageService messageService, DailyNecessitiesUserRequestMessageService userRequestMessageService) {
+            DailyNecessitiesDonationService donationService, DailyNecessitiesCenterMessageService messageService, DailyNecessitiesUserRequestMessageService userRequestMessageService, DailyNecessitiesRestockForecastService restockForecastService) {
         this.necessitiesService = necessitiesService;
         this.requestService = requestService;
         this.stockService = stockService;
@@ -38,6 +41,7 @@ public class DailyNecessitiesController {
         this.donationService = donationService;
         this.messageService = messageService;
         this.userRequestMessageService = userRequestMessageService;
+        this.restockForecastService = restockForecastService;
     }
 
     // ------------------------------------
@@ -340,6 +344,33 @@ public class DailyNecessitiesController {
     public ResponseEntity<String> markAsProcessed(@PathVariable Long id) {
         userRequestMessageService.markAsProcessed(id);
         return ResponseEntity.ok("요청 처리 완료 상태로 변경했습니다.");
+    }
+
+    //-----------------------------------------
+    //자동 재고 예측 및 발주 제안 기능
+    //----------------------------------------
+
+    // 1. 발주 제안 목록 조회
+    @Operation(summary = "발주 제안 목록 조회", description = "부족이 예상되는 품목의 자동 발주 제안 목록을 조회합니다.")
+    @GetMapping("/forecast/suggestions")
+    public ResponseEntity<List<DailyNecessitiesRestockSuggestion>> getSuggestions() {
+        return ResponseEntity.ok(restockForecastService.getPendingSuggestions());
+    }
+
+    // 2. 발주 제안 승인
+    @Operation(summary = "발주 제안 승인", description = "관리자가 발주 제안을 승인합니다.")
+    @PatchMapping("/forecast/suggestions/{id}/approve")
+    public ResponseEntity<String> approveSuggestion(@PathVariable Long id) {
+        restockForecastService.approveSuggestion(id);
+        return ResponseEntity.ok("발주 제안이 승인되었습니다.");
+    }
+
+    //3. 발주 제안 거절
+    @Operation(summary = "발주 제안 거절", description = "관리자가 발주 제안을 거절합니다.")
+    @PatchMapping("/forecast/suggestions/{id}/reject")
+    public ResponseEntity<String> rejectSuggestion(@PathVariable Long id) {
+        restockForecastService.rejectSuggestion(id);
+        return ResponseEntity.ok("발주 제안이 거절되었습니다.");
     }
 
 

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessitiesRestockSuggestion.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessitiesRestockSuggestion.java
@@ -1,0 +1,37 @@
+package com.save_help.Save_Help.dailyNecessities.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class DailyNecessitiesRestockSuggestion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 어떤 생필품인지
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "necessity_id", nullable = false)
+    private DailyNecessities necessity;
+
+    // 예측된 부족 시점
+    private LocalDateTime predictedOutOfStockDate;
+
+    // 제안 생성일
+    private LocalDateTime createdAt;
+
+    // 제안 상태: PENDING / APPROVED / REJECTED
+    @Enumerated(EnumType.STRING)
+    private SuggestionStatus status;
+
+    public enum SuggestionStatus {
+        PENDING, APPROVED, REJECTED
+    }
+}

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesHistoryRepository.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesHistoryRepository.java
@@ -2,6 +2,8 @@ package com.save_help.Save_Help.dailyNecessities.repository;
 
 import com.save_help.Save_Help.dailyNecessities.entity.DailyNecessitiesHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -13,4 +15,14 @@ public interface DailyNecessitiesHistoryRepository extends JpaRepository<DailyNe
     List<DailyNecessitiesHistory> findByItem_ProvidedBy_Id(Long centerId);
 
     List<DailyNecessitiesHistory> findByTimestampBetween(LocalDateTime start, LocalDateTime end);
+
+    @Query("""
+    SELECT COALESCE(SUM(h.changeQuantity) / 7, 0)
+    FROM DailyNecessitiesHistory h
+    WHERE h.item.id = :itemId
+      AND h.changeQuantity < 0
+      AND h.changedAt >= CURRENT_DATE - 7
+    """)
+    int getAverageDailyUsage(@Param("itemId") Long itemId, int days);
+
 }

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesRestockSuggestionRepository.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesRestockSuggestionRepository.java
@@ -1,0 +1,11 @@
+package com.save_help.Save_Help.dailyNecessities.repository;
+
+import com.save_help.Save_Help.dailyNecessities.entity.DailyNecessities;
+import com.save_help.Save_Help.dailyNecessities.entity.DailyNecessitiesRestockSuggestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface DailyNecessitiesRestockSuggestionRepository extends JpaRepository<DailyNecessitiesRestockSuggestion, Long> {
+    List<DailyNecessitiesRestockSuggestion> findByStatus(DailyNecessitiesRestockSuggestion.SuggestionStatus status);
+}

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/service/DailyNecessitiesRestockForecastService.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/service/DailyNecessitiesRestockForecastService.java
@@ -1,0 +1,65 @@
+package com.save_help.Save_Help.dailyNecessities.service;
+
+import com.save_help.Save_Help.dailyNecessities.entity.*;
+import com.save_help.Save_Help.dailyNecessities.repository.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DailyNecessitiesRestockForecastService {
+
+    private final DailyNecessitiesRepository necessitiesRepository;
+    private final DailyNecessitiesHistoryRepository historyRepository;
+    private final DailyNecessitiesRestockSuggestionRepository suggestionRepository;
+
+    @Scheduled(cron = "0 0 7 * * *")
+    public void generateRestockSuggestions() {
+        log.info("자동 재고 예측 및 발주 제안 생성 시작...");
+
+        List<DailyNecessities> allItems = necessitiesRepository.findAll();
+        for (DailyNecessities item : allItems) {
+            int avgDailyUsage = historyRepository.getAverageDailyUsage(item.getId(), 7); // 최근 7일 평균 사용량
+            if (avgDailyUsage <= 0) continue;
+
+            int currentStock = item.getStock();
+            int daysLeft = currentStock / avgDailyUsage;
+
+            if (daysLeft <= 3) { // 3일 이하 남으면 발주 제안
+                DailyNecessitiesRestockSuggestion suggestion = DailyNecessitiesRestockSuggestion.builder()
+                        .necessity(item)
+                        .predictedOutOfStockDate(LocalDateTime.now().plusDays(daysLeft))
+                        .createdAt(LocalDateTime.now())
+                        .status(DailyNecessitiesRestockSuggestion.SuggestionStatus.PENDING)
+                        .build();
+
+                suggestionRepository.save(suggestion);
+                log.info("발주 제안 생성 - {} (예상 소진일: {})", item.getName(), suggestion.getPredictedOutOfStockDate());
+            }
+        }
+    }
+
+    public List<DailyNecessitiesRestockSuggestion> getPendingSuggestions() {
+        return suggestionRepository.findByStatus(DailyNecessitiesRestockSuggestion.SuggestionStatus.PENDING);
+    }
+
+    public void approveSuggestion(Long id) {
+        suggestionRepository.findById(id).ifPresent(s -> {
+            s.setStatus(DailyNecessitiesRestockSuggestion.SuggestionStatus.APPROVED);
+            suggestionRepository.save(s);
+        });
+    }
+
+    public void rejectSuggestion(Long id) {
+        suggestionRepository.findById(id).ifPresent(s -> {
+            s.setStatus(DailyNecessitiesRestockSuggestion.SuggestionStatus.REJECTED);
+            suggestionRepository.save(s);
+        });
+    }
+}


### PR DESCRIPTION
## 📌 [Feat] 생필품 자동 재고 예측 및 발주 제안 기능 개발


---

## ✨ 작업 개요
- 최근 N일간 출고량(사용량)을 분석해 생필품 예상 소진 시점을 예측합니다.
- 기준 임계치 이하로 예측될 경우 발주 제안 리스트를 자동 생성합니다.
- 관리자/센터가 확인할 수 있도록 REST API를 개발하였습니다.
---

## 🔨 변경 사항

---

## ✅ 체크리스트
- [x] RestockSuggestion 엔티티 생성
- [x] RestockSuggestionRepository
- [x] RestockForecastService
- [x] DailyNecessitiesHistoryRepository 확장
- [x] Controller 작성
- [x] 최근 7일간 평균 사용량 계산 : (재고 / 사용량)으로 남은 일수 계산
- [x] 자동 재고 예측 및 발주 제안 생성 기능 개발

---

## 📷 스크린샷 (선택)
<!-- UI 작업 시 스크린샷이나 API 응답 예시를 첨부하면 좋아요 -->

---

## 🔗 관련 이슈
<!-- 관련된 이슈 번호가 있다면 적어주세요 -->
- close #이슈번호