### PR TITLE
[Feat] 생필품 자동 재신청 기능 개발

### DIFF
--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/controller/DailyNecessitiesController.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/controller/DailyNecessitiesController.java
@@ -23,7 +23,7 @@ public class DailyNecessitiesController {
     private final DailyNecessitiesCenterMessageService messageService;
     private final DailyNecessitiesUserRequestMessageService userRequestMessageService;
     private final DailyNecessitiesRestockForecastService restockForecastService;
-
+    private final DailyNecessitiesAutoReorderService dailyNecessitiesAutoReorderService;
 
 
     public DailyNecessitiesController(
@@ -32,7 +32,7 @@ public class DailyNecessitiesController {
             DailyNecessitiesStockService stockService,
             DailyNecessitiesStatisticsService statisticsService,
             DailyNecessitiesReportService reportService,
-            DailyNecessitiesDonationService donationService, DailyNecessitiesCenterMessageService messageService, DailyNecessitiesUserRequestMessageService userRequestMessageService, DailyNecessitiesRestockForecastService restockForecastService) {
+            DailyNecessitiesDonationService donationService, DailyNecessitiesCenterMessageService messageService, DailyNecessitiesUserRequestMessageService userRequestMessageService, DailyNecessitiesRestockForecastService restockForecastService, DailyNecessitiesAutoReorderService dailyNecessitiesAutoReorderService) {
         this.necessitiesService = necessitiesService;
         this.requestService = requestService;
         this.stockService = stockService;
@@ -42,6 +42,7 @@ public class DailyNecessitiesController {
         this.messageService = messageService;
         this.userRequestMessageService = userRequestMessageService;
         this.restockForecastService = restockForecastService;
+        this.dailyNecessitiesAutoReorderService = dailyNecessitiesAutoReorderService;
     }
 
     // ------------------------------------
@@ -373,5 +374,31 @@ public class DailyNecessitiesController {
         return ResponseEntity.ok("발주 제안이 거절되었습니다.");
     }
 
+    //-------------------------------
+    // 생필품 자동 재신청
+    //----------------------------------
+    @Operation(summary = "자동 재신청 설정 생성", description = "사용자가 특정 품목을 일정 주기로 자동 신청하도록 설정합니다.")
+    @PostMapping("/create")
+    public ResponseEntity<AutoReorderSetting> createSetting(
+            @RequestParam Long userId,
+            @RequestParam Long itemId,
+            @RequestParam int quantity,
+            @RequestParam int intervalDays
+    ) {
+        return ResponseEntity.ok(dailyNecessitiesAutoReorderService.createSetting(userId, itemId, quantity, intervalDays));
+    }
+
+    @Operation(summary = "자동 재신청 설정 비활성화", description = "사용자의 자동 재신청 기능을 중단합니다.")
+    @PatchMapping("/{id}/deactivate")
+    public ResponseEntity<String> deactivate(@PathVariable Long id) {
+        dailyNecessitiesAutoReorderService.deactivate(id);
+        return ResponseEntity.ok("자동 재신청이 비활성화되었습니다.");
+    }
+
+    @Operation(summary = "사용자 자동 재신청 설정 조회", description = "사용자의 모든 자동 재신청 설정을 조회합니다.")
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<List<AutoReorderSetting>> getUserSettings(@PathVariable Long userId) {
+        return ResponseEntity.ok(dailyNecessitiesAutoReorderService.getUserSettings(userId));
+    }
 
 }

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/AutoReorderSetting.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/AutoReorderSetting.java
@@ -1,0 +1,29 @@
+package com.save_help.Save_Help.dailyNecessities.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class AutoReorderSetting {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;       // 사용자 ID
+    private Long itemId;       // 생필품 ID
+    private int quantity;      // 자동 신청 수량
+
+    private int intervalDays;  // 자동 신청 주기 (ex: 7일마다)
+
+    private LocalDateTime nextReorderAt;  // 다음 자동 신청 예정일
+
+    private boolean active = true;        // 자동 신청 활성화 여부
+}

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessitiesAutoRequest.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessitiesAutoRequest.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 @Setter
 @NoArgsConstructor
 @Entity
-public class AutoRequest {
+public class DailyNecessitiesAutoRequest {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,7 +31,7 @@ public class AutoRequest {
 
     private LocalDateTime requestedAt = LocalDateTime.now();
 
-    public AutoRequest(DailyNecessities item, CommunityCenter center, Integer quantity) {
+    public DailyNecessitiesAutoRequest(DailyNecessities item, CommunityCenter center, Integer quantity) {
         this.item = item;
         this.center = center;
         this.quantity = quantity;

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesAutoReorderSettingRepository.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesAutoReorderSettingRepository.java
@@ -1,0 +1,12 @@
+package com.save_help.Save_Help.dailyNecessities.repository;
+
+import com.save_help.Save_Help.dailyNecessities.entity.AutoReorderSetting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface DailyNecessitiesAutoReorderSettingRepository  extends JpaRepository<AutoReorderSetting, Long> {
+
+    List<AutoReorderSetting> findByActiveTrueAndNextReorderAtBefore(LocalDateTime now);
+}

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/service/DailyNecessitiesAutoReorderService.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/service/DailyNecessitiesAutoReorderService.java
@@ -1,0 +1,88 @@
+package com.save_help.Save_Help.dailyNecessities.service;
+
+import com.save_help.Save_Help.dailyNecessities.entity.*;
+import com.save_help.Save_Help.dailyNecessities.repository.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DailyNecessitiesAutoReorderService {
+
+    private final DailyNecessitiesAutoReorderSettingRepository reorderRepo;
+    private final UserNecessityRequestService requestService;
+    private final DailyNecessitiesStockService stockService;
+    private final DailyNecessitiesNotificationService notificationService;
+
+    //7시간마다 자동 재신청 수행
+    @Scheduled(cron = "0 0 */7 * * *")
+    public void processAutoReorders() {
+        List<AutoReorderSetting> dueReorders =
+                reorderRepo.findByActiveTrueAndNextReorderAtBefore(LocalDateTime.now());
+
+        for (AutoReorderSetting setting : dueReorders) {
+            try {
+                DailyNecessities item = stockService.getItem(setting.getItemId());
+
+                // 재고 확인
+                if (item.getStock() < setting.getQuantity()) {
+                    notificationService.notifyAdmin(
+                            "재고 부족: " + item.getName() + " 자동 재신청 실패 (userId=" + setting.getUserId() + ")"
+                    );
+                    continue;
+                }
+
+                // 자동 신청 생성
+                requestService.createRequest(
+                        setting.getUserId(),
+                        setting.getItemId(),
+                        setting.getQuantity()
+                );
+
+                // 다음 신청일 업데이트
+                setting.setNextReorderAt(LocalDateTime.now().plusDays(setting.getIntervalDays()));
+                reorderRepo.save(setting);
+
+                // 사용자 알림
+                notificationService.notifyUser(setting.getUserId(),
+                        item.getName() + "이(가) 자동으로 신청되었습니다.");
+
+                log.info("자동 재신청 완료: user={} item={} qty={}", setting.getUserId(), setting.getItemId(), setting.getQuantity());
+
+            } catch (Exception e) {
+                log.error("자동 재신청 실패 (settingId={}): {}", setting.getId(), e.getMessage());
+            }
+        }
+    }
+
+    public AutoReorderSetting createSetting(Long userId, Long itemId, int quantity, int intervalDays) {
+        AutoReorderSetting setting = AutoReorderSetting.builder()
+                .userId(userId)
+                .itemId(itemId)
+                .quantity(quantity)
+                .intervalDays(intervalDays)
+                .nextReorderAt(LocalDateTime.now().plusDays(intervalDays))
+                .active(true)
+                .build();
+        return reorderRepo.save(setting);
+    }
+
+    public void deactivate(Long settingId) {
+        reorderRepo.findById(settingId).ifPresent(setting -> {
+            setting.setActive(false);
+            reorderRepo.save(setting);
+        });
+    }
+
+    public List<AutoReorderSetting> getUserSettings(Long userId) {
+        return reorderRepo.findAll().stream()
+                .filter(s -> s.getUserId().equals(userId))
+                .toList();
+    }
+}

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/service/DailyNecessitiesNotificationService.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/service/DailyNecessitiesNotificationService.java
@@ -1,0 +1,18 @@
+package com.save_help.Save_Help.dailyNecessities.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class DailyNecessitiesNotificationService {
+
+    //임시
+    public void notifyUser(Long userId, String message) {
+        log.info("[USER {} 알림] {}", userId, message);
+    }
+
+    public void notifyAdmin(String message) {
+        log.warn("[관리자 알림] {}", message);
+    }
+}

--- a/src/main/java/com/save_help/Save_Help/helper/entity/Helper.java
+++ b/src/main/java/com/save_help/Save_Help/helper/entity/Helper.java
@@ -50,6 +50,32 @@ public class Helper {
     @OneToMany(mappedBy = "helper", cascade = CascadeType.ALL)
     private List<HelperEmergencyContact> helperEmergencyContacts = new ArrayList<>();
 
+    //@Enumerated(EnumType.STRING)
+    //private HelperActivityStatus activityStatus = HelperActivityStatus.OFF_DUTY;
+
+    // 활동 상태
     @Enumerated(EnumType.STRING)
-    private HelperActivityStatus activityStatus = HelperActivityStatus.OFF_DUTY;
+    @Column(nullable = false)
+    private HelperActivityStatus activityStatus = HelperActivityStatus.AVAILABLE;
+
+    // 신뢰도 점수 (평균 평점 기반)
+    @Column(nullable = false)
+    private Double trustScore = 5.0;
+
+    // 최근 평가 갱신일 (선택사항)
+    private java.time.LocalDateTime lastReviewUpdate;
+
+    // 신뢰도 업데이트 메서드
+    public void updateTrustScore(Double newScore) {
+        this.trustScore = newScore;
+        this.lastReviewUpdate = java.time.LocalDateTime.now();
+
+        // 평균 평점이 2.5 미만이면 상태 변경
+        if (newScore < 2.5) {
+            this.activityStatus = HelperActivityStatus.REVIEW_REQUIRED;
+        } else if (this.activityStatus == HelperActivityStatus.REVIEW_REQUIRED && newScore >= 3.0) {
+            // 신뢰도 회복 시 복귀
+            this.activityStatus = HelperActivityStatus.AVAILABLE;
+        }
+    }
 }


### PR DESCRIPTION
## 📌 [Feat] 생필품 자동 재신청 기능 개발


---

## ✨ 작업 개요
- 사용자가 특정 생필품을 반복적으로 신청할 경우, 매번 수동으로 신청하지 않아도 자동으로 재신청되도록 하는 기능을 개발합니다.
- 사용자가 “자동 재신청” 설정 (특정 품목, 주기, 수량 입력) 시 스케줄러가 주기적으로 검사
- 설정된 시간이 되면 자동으로 UserNecessityRequest 생성, 성공 시 사용자에게 “자동 신청 완료” 알림 발송
---

## 🔨 변경 사항

---

## ✅ 체크리스트
- [x] AutoReorderSetting 엔티티 생성
- [x] AutoReorderSettingRepository
- [x] AutoReorderService
- [x] AutoReorderController
- [x] DailyNecessitiesNotificationService
- [x] 자동 재신청 설정 활성화/비활성화 기능 개발
- [x] 사용자 자동 재신청 설정 조회 기능 개발

---

## 📷 스크린샷 (선택)
<!-- UI 작업 시 스크린샷이나 API 응답 예시를 첨부하면 좋아요 -->

---

## 🔗 관련 이슈
<!-- 관련된 이슈 번호가 있다면 적어주세요 -->
- close #이슈번호