### PR TITLE
[Feat] 생필품 기능 기부 포인트 기능 개발

### DIFF
--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/controller/DailyNecessitiesController.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/controller/DailyNecessitiesController.java
@@ -2,7 +2,10 @@ package com.save_help.Save_Help.dailyNecessities.controller;
 
 import com.save_help.Save_Help.dailyNecessities.dto.*;
 import com.save_help.Save_Help.dailyNecessities.entity.*;
+import com.save_help.Save_Help.dailyNecessities.repository.DailyNecessitiesDonationPointHistoryRepository;
 import com.save_help.Save_Help.dailyNecessities.service.*;
+import com.save_help.Save_Help.user.entity.User;
+import com.save_help.Save_Help.user.repository.UserRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -24,7 +27,8 @@ public class DailyNecessitiesController {
     private final DailyNecessitiesUserRequestMessageService userRequestMessageService;
     private final DailyNecessitiesRestockForecastService restockForecastService;
     private final DailyNecessitiesAutoReorderService dailyNecessitiesAutoReorderService;
-
+    private final UserRepository userRepository;
+    private final DailyNecessitiesDonationPointHistoryRepository historyRepository;
 
     public DailyNecessitiesController(
             DailyNecessitiesService necessitiesService,
@@ -32,7 +36,7 @@ public class DailyNecessitiesController {
             DailyNecessitiesStockService stockService,
             DailyNecessitiesStatisticsService statisticsService,
             DailyNecessitiesReportService reportService,
-            DailyNecessitiesDonationService donationService, DailyNecessitiesCenterMessageService messageService, DailyNecessitiesUserRequestMessageService userRequestMessageService, DailyNecessitiesRestockForecastService restockForecastService, DailyNecessitiesAutoReorderService dailyNecessitiesAutoReorderService) {
+            DailyNecessitiesDonationService donationService, DailyNecessitiesCenterMessageService messageService, DailyNecessitiesUserRequestMessageService userRequestMessageService, DailyNecessitiesRestockForecastService restockForecastService, DailyNecessitiesAutoReorderService dailyNecessitiesAutoReorderService, UserRepository userRepository, DailyNecessitiesDonationPointHistoryRepository historyRepository) {
         this.necessitiesService = necessitiesService;
         this.requestService = requestService;
         this.stockService = stockService;
@@ -43,6 +47,8 @@ public class DailyNecessitiesController {
         this.userRequestMessageService = userRequestMessageService;
         this.restockForecastService = restockForecastService;
         this.dailyNecessitiesAutoReorderService = dailyNecessitiesAutoReorderService;
+        this.userRepository = userRepository;
+        this.historyRepository = historyRepository;
     }
 
     // ------------------------------------
@@ -412,6 +418,17 @@ public class DailyNecessitiesController {
         return ResponseEntity.ok(recommendations);
     }
 
+    //-------------------------------
+    // 사용자 생필품 기부 내역 히스토리 조회
+    //----------------------------------
+
+    @Operation(summary = "사용자 생필품 기부 내역 히스토리 조회", description = "사용자의 생필품 기부 내역을 기반으로 기부 내역을 조회합니다.")
+    @GetMapping("/donations/points/history/{userId}")
+    public ResponseEntity<List<DonationPointHistory>> getPointHistory(@PathVariable Long userId) {
+        User donor = userRepository.findById(userId).orElseThrow();
+        List<DonationPointHistory> history = historyRepository.findByDonor(donor);
+        return ResponseEntity.ok(history);
+    }
 
 
 }

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DonationPointHistory.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DonationPointHistory.java
@@ -1,0 +1,33 @@
+package com.save_help.Save_Help.dailyNecessities.entity;
+
+
+import com.save_help.Save_Help.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DonationPointHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User donor; // 기부자
+
+    @ManyToOne
+    @JoinColumn(name = "donation_id")
+    private DailyNecessitiesDonation donation; // 관련 기부 내역
+
+    private int points; // 적립된 포인트
+    private LocalDateTime createdAt; // 적립 시각
+
+}

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesDonationPointHistoryRepository.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesDonationPointHistoryRepository.java
@@ -1,0 +1,10 @@
+package com.save_help.Save_Help.dailyNecessities.repository;
+import com.save_help.Save_Help.dailyNecessities.entity.DonationPointHistory;
+import com.save_help.Save_Help.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface DailyNecessitiesDonationPointHistoryRepository extends JpaRepository<DonationPointHistory, Long> {
+    List<DonationPointHistory> findByDonor(User donor);
+}

--- a/src/main/java/com/save_help/Save_Help/user/entity/User.java
+++ b/src/main/java/com/save_help/Save_Help/user/entity/User.java
@@ -66,5 +66,6 @@ public class User {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<HelperEmergencyContact> helperEmergencyContacts = new ArrayList<>();
 
-
+    @Column(name = "total_donation_points")
+    private int totalDonationPoints; // 누적 기부 포인트
 }


### PR DESCRIPTION
## 📌 [Feat] 생필품 기능 기부 포인트 기능 개발


---

## ✨ 작업 개요
- 생필품 기부 내역에 따른 포인트 적립 기능을 개발하였습니다.
- 기부 내역을 포인트 계산 규칙에 따라 기부 발생 시 자동으로 포인트를 계산합니다.
- 기부자의 개별 기부 내역별 포인트 기록을 저장, 조회하는 기능을 개발하였습니다.
---

## 🔨 변경 사항

---

## ✅ 체크리스트
- [x] DonationPointHistory 엔티티 생성 및 테이블 매핑
- [x] User의 누적 포인트 필드 추가
- [x] DonationPointService의 포인트 계산 정책 구현
- [x] 기부 발생 시 포인트 적립 기능 개발
- [x] DonationPointHistoryRepository 생성
- [x] 기부 히스토리 조회 기능 개발
- [x] Swagger 문서화


---

## 📷 스크린샷 (선택)
<!-- UI 작업 시 스크린샷이나 API 응답 예시를 첨부하면 좋아요 -->

---

## 🔗 관련 이슈
<!-- 관련된 이슈 번호가 있다면 적어주세요 -->
- close #이슈번호