### PR TITLE
[Feat] 생필품 자동 신청 기능 개발

### DIFF
--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/controller/DailyNecessitiesController.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/controller/DailyNecessitiesController.java
@@ -30,6 +30,7 @@ public class DailyNecessitiesController {
     private final UserRepository userRepository;
     private final DailyNecessitiesDonationPointHistoryRepository historyRepository;
     private final DailyNecessitiesDeliveryService deliveryService;
+    private final DailyNecessitiesAutoRequestService autoRequestService;
 
     public DailyNecessitiesController(
             DailyNecessitiesService necessitiesService,
@@ -37,7 +38,7 @@ public class DailyNecessitiesController {
             DailyNecessitiesStockService stockService,
             DailyNecessitiesStatisticsService statisticsService,
             DailyNecessitiesReportService reportService,
-            DailyNecessitiesDonationService donationService, DailyNecessitiesCenterMessageService messageService, DailyNecessitiesUserRequestMessageService userRequestMessageService, DailyNecessitiesRestockForecastService restockForecastService, DailyNecessitiesAutoReorderService dailyNecessitiesAutoReorderService, UserRepository userRepository, DailyNecessitiesDonationPointHistoryRepository historyRepository, DailyNecessitiesDeliveryService deliveryService) {
+            DailyNecessitiesDonationService donationService, DailyNecessitiesCenterMessageService messageService, DailyNecessitiesUserRequestMessageService userRequestMessageService, DailyNecessitiesRestockForecastService restockForecastService, DailyNecessitiesAutoReorderService dailyNecessitiesAutoReorderService, UserRepository userRepository, DailyNecessitiesDonationPointHistoryRepository historyRepository, DailyNecessitiesDeliveryService deliveryService, DailyNecessitiesAutoRequestService autoRequestService) {
         this.necessitiesService = necessitiesService;
         this.requestService = requestService;
         this.stockService = stockService;
@@ -51,6 +52,7 @@ public class DailyNecessitiesController {
         this.userRepository = userRepository;
         this.historyRepository = historyRepository;
         this.deliveryService = deliveryService;
+        this.autoRequestService = autoRequestService;
     }
 
     // ------------------------------------
@@ -452,6 +454,27 @@ public class DailyNecessitiesController {
         return ResponseEntity.ok("현재 배송 상태는 " + delivery.getStatus() + " 입니다.");
     }
 
+    // 생필품 자동 신청 실행 api
 
+    @Operation(summary = "사용자 요청 기반 자동신청 실행", description = "사용자가 요청한 생필품 이름과 카테고리를 기반으로 자동신청을 실행합니다.")
+    @PostMapping("/auto/apply")
+    public ResponseEntity<String> autoApply(
+            @RequestParam Long userId,
+            @RequestParam String name,
+            @RequestParam(required = false) String category,
+            @RequestParam(defaultValue = "1") int quantity
+    ) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        autoRequestService.autoRequestIfStockAvailable(
+                user,
+                name,
+                category != null ? NecessityCategory.valueOf(category) : null,
+                quantity
+        );
+
+        return ResponseEntity.ok("자동신청이 완료되었습니다.");
+    }
 
 }

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/UserNecessityRequest.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/UserNecessityRequest.java
@@ -40,6 +40,6 @@ public class UserNecessityRequest {
     }
 
     public enum RequestStatus {
-        PENDING, APPROVED, REJECTED
+        PENDING, APPROVED, COMPLETED, REJECTED, AUTO_APPLIED
     }
 }

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesRepository.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesRepository.java
@@ -3,6 +3,7 @@ package com.save_help.Save_Help.dailyNecessities.repository;
 import com.save_help.Save_Help.dailyNecessities.entity.DailyNecessities;
 import com.save_help.Save_Help.dailyNecessities.entity.NecessityCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Arrays;
@@ -30,6 +31,12 @@ public interface DailyNecessitiesRepository extends JpaRepository<DailyNecessiti
     List<DailyNecessities> findByCategoryInAndStockGreaterThan(List<NecessityCategory> topCategories, int stock);
 
     List<DailyNecessities> findTop10ByOrderByRequestCountDesc();
+
+    // 특정 카테고리 또는 이름으로 활성 + 승인된 재고 검색
+    @Query("SELECT d FROM DailyNecessities d WHERE d.active = true AND d.approvalStatus = 'APPROVED' " +
+            "AND (d.name = :name OR d.category = :category) AND d.stock > 0")
+    List<DailyNecessities> findAvailableByNameOrCategory(String name, NecessityCategory category);
+
     //List<DailyNecessities> findByCategoryAndApprovalStatus(DailyNecessities.NecessityCategory category, DailyNecessities.ApprovalStatus status);
 
 

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/service/DailyNecessitiesAutoRequestService.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/service/DailyNecessitiesAutoRequestService.java
@@ -1,0 +1,116 @@
+package com.save_help.Save_Help.dailyNecessities.service;
+
+import com.save_help.Save_Help.dailyNecessities.entity.*;
+import com.save_help.Save_Help.dailyNecessities.repository.DailyNecessitiesRepository;
+import com.save_help.Save_Help.dailyNecessities.repository.UserNecessityRequestRepository;
+import com.save_help.Save_Help.user.entity.User;
+import jakarta.persistence.EntityNotFoundException;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class DailyNecessitiesAutoRequestService {
+
+    private final DailyNecessitiesRepository necessitiesRepository;
+    private final UserNecessityRequestRepository requestRepository;
+    private final RedissonClient redissonClient;
+
+    public DailyNecessitiesAutoRequestService(
+            DailyNecessitiesRepository necessitiesRepository,
+            UserNecessityRequestRepository requestRepository,
+            RedissonClient redissonClient
+    ) {
+        this.necessitiesRepository = necessitiesRepository;
+        this.requestRepository = requestRepository;
+        this.redissonClient = redissonClient;
+    }
+
+    // Redisson 락 사용
+    private RLock getLock(Long necessityId) {
+        return redissonClient.getLock("lock:necessity:" + necessityId);
+    }
+
+
+    // 사용자가 과거 수급받았던 생필품이 재고에 들어온 경우 자동 신청
+    @Transactional
+    public void autoRequestBasedOnPastReceipts(User user, List<DailyNecessities> pastReceivedItems) {
+        for (DailyNecessities pastItem : pastReceivedItems) {
+            List<DailyNecessities> availableList =
+                    necessitiesRepository.findAvailableByNameOrCategory(pastItem.getName(), pastItem.getCategory());
+
+            for (DailyNecessities available : availableList) {
+                RLock lock = getLock(available.getId());
+                boolean locked = false;
+
+                try {
+                    locked = lock.tryLock(3, 7, TimeUnit.SECONDS);
+                    if (!locked) continue;
+
+                    if (available.getStock() > 0) {
+                        createAutoRequest(user, available, 1);
+                        available.setStock(available.getStock() - 1);
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException("락을 획득하는 중 오류가 발생했습니다.", e);
+                } finally {
+                    if (locked && lock.isHeldByCurrentThread()) {
+                        lock.unlock();
+                    }
+                }
+            }
+        }
+    }
+
+
+    // 사용자가 요청한 생필품이 재고에 존재할 경우 자동 신청 처리
+    @Transactional
+    public void autoRequestIfStockAvailable(User user, String requestedName, NecessityCategory category, int quantity) {
+        List<DailyNecessities> availableList =
+                necessitiesRepository.findAvailableByNameOrCategory(requestedName, category);
+
+        if (availableList.isEmpty())
+            throw new EntityNotFoundException("요청한 생필품이 현재 재고에 존재하지 않습니다.");
+
+        DailyNecessities item = availableList.get(0);
+        RLock lock = getLock(item.getId());
+        boolean locked = false;
+
+        try {
+            locked = lock.tryLock(3, 7, TimeUnit.SECONDS);
+            if (!locked)
+                throw new IllegalStateException("다른 사용자가 동일한 품목을 처리 중입니다. 잠시 후 다시 시도해주세요.");
+
+            if (item.getStock() >= quantity) {
+                createAutoRequest(user, item, quantity);
+                item.setStock(item.getStock() - quantity);
+            } else {
+                throw new IllegalStateException("요청한 수량만큼의 재고가 부족합니다.");
+            }
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("락을 획득하는 중 스레드가 인터럽트되었습니다.", e);
+        } finally {
+            if (locked && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
+    }
+
+
+    // 자동 신청 생성 메서드
+    private void createAutoRequest(User user, DailyNecessities item, int quantity) {
+        UserNecessityRequest request = new UserNecessityRequest();
+        request.setUser(user);
+        request.setItem(item);
+        request.setQuantity(quantity);
+        request.setStatus(UserNecessityRequest.RequestStatus.AUTO_APPLIED);
+        requestRepository.save(request);
+    }
+}


### PR DESCRIPTION
## 📌 [Feat] 생필품 자동 신청 기능 개발


---

## ✨ 작업 개요
- 사용자가 과거에 지급받았던 생필품이 재고에 들어오면 자동으로 신청을 생성하는 기능을 개발하였습니다.
- 사용자가 요청한 생필품이 재고에 들어올 경우 자동으로 신청을 생성하는 기능을 개발할 예정입니다.
- 재고가 없는 경우 대기 상태로 유지하도록 하였습니다. 
---

## 🔨 변경 사항

---

## ✅ 체크리스트
- [x] Redisson 기반 분산 락(RLock) 적용으로 중복 차감 방지
- [x] 생필품별 락(lock:necessity:{id}) 생성 구조 설계
- [x] 자동 신청 시 트랜잭션 + 락으로 원자성 보장
- [x] 사용자 요청/과거 수급 기록 기반 자동 신청 구현
- [x] 재고 부족 / 처리 중 충돌 예외 처리
- [x] 생필품 자동 신청 API 개발
- [x] Swagger 문서화


---

## 📷 스크린샷 (선택)
<!-- UI 작업 시 스크린샷이나 API 응답 예시를 첨부하면 좋아요 -->

---

## 🔗 관련 이슈
<!-- 관련된 이슈 번호가 있다면 적어주세요 -->
- close #이슈번호