### PR TITLE
[Feat] Redis 캐시 기반 Helper 조회 기능

### DIFF
--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/controller/DailyNecessitiesController.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/controller/DailyNecessitiesController.java
@@ -30,6 +30,7 @@ public class DailyNecessitiesController {
     private final UserRepository userRepository;
     private final DailyNecessitiesDonationPointHistoryRepository historyRepository;
     private final DailyNecessitiesDeliveryService deliveryService;
+    private final DailyNecessitiesReviewService reviewService;
 
     public DailyNecessitiesController(
             DailyNecessitiesService necessitiesService,
@@ -37,7 +38,7 @@ public class DailyNecessitiesController {
             DailyNecessitiesStockService stockService,
             DailyNecessitiesStatisticsService statisticsService,
             DailyNecessitiesReportService reportService,
-            DailyNecessitiesDonationService donationService, DailyNecessitiesCenterMessageService messageService, DailyNecessitiesUserRequestMessageService userRequestMessageService, DailyNecessitiesRestockForecastService restockForecastService, DailyNecessitiesAutoReorderService dailyNecessitiesAutoReorderService, UserRepository userRepository, DailyNecessitiesDonationPointHistoryRepository historyRepository, DailyNecessitiesDeliveryService deliveryService) {
+            DailyNecessitiesDonationService donationService, DailyNecessitiesCenterMessageService messageService, DailyNecessitiesUserRequestMessageService userRequestMessageService, DailyNecessitiesRestockForecastService restockForecastService, DailyNecessitiesAutoReorderService dailyNecessitiesAutoReorderService, UserRepository userRepository, DailyNecessitiesDonationPointHistoryRepository historyRepository, DailyNecessitiesDeliveryService deliveryService, DailyNecessitiesReviewService reviewService) {
         this.necessitiesService = necessitiesService;
         this.requestService = requestService;
         this.stockService = stockService;
@@ -51,6 +52,7 @@ public class DailyNecessitiesController {
         this.userRepository = userRepository;
         this.historyRepository = historyRepository;
         this.deliveryService = deliveryService;
+        this.reviewService = reviewService;
     }
 
     // ------------------------------------
@@ -452,6 +454,25 @@ public class DailyNecessitiesController {
         return ResponseEntity.ok("현재 배송 상태는 " + delivery.getStatus() + " 입니다.");
     }
 
+    //-------------------------------
+    // 생필품 리뷰 등록/조회 기능
+    //----------------------------------
 
+    @Operation(summary = "생필품 리뷰 등록", description = "사용자가 받은 생필품에 대한 리뷰를 작성합니다.")
+    @PostMapping("/reviews")
+    public ResponseEntity<DailyNecessitiesReviewDto> createReview(
+            @RequestParam Long userId,
+            @RequestParam Long itemId,
+            @RequestParam int rating,
+            @RequestParam(required = false) String comment
+    ) {
+        return ResponseEntity.ok(reviewService.createReview(userId, itemId, rating, comment));
+    }
+
+    @Operation(summary = "생필품 리뷰 조회", description = "특정 품목의 리뷰 목록을 조회합니다.")
+    @GetMapping("/reviews/{itemId}")
+    public ResponseEntity<List<DailyNecessitiesReviewDto>> getReviews(@PathVariable Long itemId) {
+        return ResponseEntity.ok(reviewService.getReviewsByItem(itemId));
+    }
 
 }

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessitiesReview.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessitiesReview.java
@@ -1,0 +1,31 @@
+package com.save_help.Save_Help.dailyNecessities.entity;
+
+import com.save_help.Save_Help.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter @Setter
+@NoArgsConstructor
+public class DailyNecessitiesReview {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User reviewer; // 작성자
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private DailyNecessities item; // 리뷰 대상 품목
+
+    @Column(nullable = false)
+    private int rating; // 1~5 점수
+
+    private String comment;
+
+    private LocalDateTime createdAt = LocalDateTime.now();
+}

--- a/src/main/java/com/save_help/Save_Help/global/config/RedisConfig.java
+++ b/src/main/java/com/save_help/Save_Help/global/config/RedisConfig.java
@@ -1,0 +1,35 @@
+package com.save_help.Save_Help.global.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+public class RedisConfig {
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        // 기본적으로 application.yml의 spring.redis.host, port 사용
+        return new LettuceConnectionFactory();
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory factory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+
+        // 키와 값 직렬화
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return template;
+    }
+}

--- a/src/main/java/com/save_help/Save_Help/helper/controller/HelperController.java
+++ b/src/main/java/com/save_help/Save_Help/helper/controller/HelperController.java
@@ -28,6 +28,7 @@ public class HelperController {
     private final HelperReviewService reviewService;
     private final HelperLocationService helperLocationService;
     private final HelperRecommendationService recommendationService;
+    private final HelperCacheService helperCacheService;
 
     // 생성
     @Operation(summary = "Helper 생성", description = "새로운 Helper를 등록합니다.")
@@ -285,4 +286,16 @@ public class HelperController {
         helperService.verifyCertification(id);
         return ResponseEntity.ok("자격증 검증이 완료되었습니다.");
     }
+
+
+    //--------------------------------
+    // Redis 캐시 기반 근무 가능한 Helper 조회
+    //--------------------------------
+
+    @Operation(summary = "Redis 캐시 기반 근무 가능한 Helper 조회", description = "응급 상황 시 DB 접근 없이 빠르게 근무 가능한 Helper를 캐시로 조회합니다.")
+    @GetMapping("/available/cached")
+    public ResponseEntity<List<HelperCacheDto>> getAvailableHelpersCached() {
+        return ResponseEntity.ok(helperCacheService.getAvailableHelpersCached());
+    }
+
 }

--- a/src/main/java/com/save_help/Save_Help/helper/dto/HelperCacheDto.java
+++ b/src/main/java/com/save_help/Save_Help/helper/dto/HelperCacheDto.java
@@ -1,0 +1,25 @@
+package com.save_help.Save_Help.helper.dto;
+
+import com.save_help.Save_Help.helper.entity.HelperActivityStatus;
+import com.save_help.Save_Help.helper.entity.HelperRole;
+import lombok.*;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class HelperCacheDto implements Serializable {
+    private Long id;
+    private String name;
+    private HelperRole role;
+    private boolean available;
+    private HelperActivityStatus activityStatus;
+    private Double latitude;
+    private Double longitude;
+    private Double trustScore;
+    private LocalDateTime lastLocationUpdateTime;
+}

--- a/src/main/java/com/save_help/Save_Help/helper/scheduler/HelperCacheScheduler.java
+++ b/src/main/java/com/save_help/Save_Help/helper/scheduler/HelperCacheScheduler.java
@@ -1,0 +1,23 @@
+package com.save_help.Save_Help.helper.scheduler;
+
+import com.save_help.Save_Help.helper.service.HelperCacheService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@EnableScheduling
+@RequiredArgsConstructor
+public class HelperCacheScheduler {
+
+    private final HelperCacheService cacheService;
+
+    /**
+     * 일정시간마다 캐시 리빌드 (DB → Redis)
+     */
+    @Scheduled(fixedRate = 370_000)
+    public void refreshHelperCache() {
+        cacheService.cacheAvailableHelpers();
+    }
+}

--- a/src/main/java/com/save_help/Save_Help/helper/service/HelperCacheService.java
+++ b/src/main/java/com/save_help/Save_Help/helper/service/HelperCacheService.java
@@ -1,0 +1,85 @@
+package com.save_help.Save_Help.helper.service;
+
+import com.save_help.Save_Help.helper.dto.HelperCacheDto;
+import com.save_help.Save_Help.helper.entity.Helper;
+import com.save_help.Save_Help.helper.repository.HelperRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class HelperCacheService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final HelperRepository helperRepository;
+
+    private static final String HELPER_CACHE_KEY = "helper:available";
+
+    /**
+     * 헬퍼 전체 리스트를 Redis에 캐싱 (TTL: 7분)
+     */
+    public void cacheAvailableHelpers() {
+        List<Helper> helpers = helperRepository.findAll()
+                .stream()
+                .filter(Helper::isAvailable)
+                .collect(Collectors.toList());
+
+        List<HelperCacheDto> dtoList = helpers.stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+
+        redisTemplate.opsForValue().set(HELPER_CACHE_KEY, dtoList, Duration.ofMinutes(7));
+    }
+
+    /**
+     * 캐시에서 조회 (없으면 DB → 캐시 리빌드)
+     */
+    @SuppressWarnings("unchecked")
+    public List<HelperCacheDto> getAvailableHelpersCached() {
+        Object cached = redisTemplate.opsForValue().get(HELPER_CACHE_KEY);
+        if (cached != null) {
+            return (List<HelperCacheDto>) cached;
+        }
+        cacheAvailableHelpers();
+        return (List<HelperCacheDto>) redisTemplate.opsForValue().get(HELPER_CACHE_KEY);
+    }
+
+    /**
+     * 특정 헬퍼 상태/위치 변경 시 캐시 갱신
+     */
+    public void updateHelperInCache(Helper helper) {
+        List<HelperCacheDto> current = getAvailableHelpersCached();
+        List<HelperCacheDto> updated = current.stream()
+                .filter(h -> !h.getId().equals(helper.getId()))
+                .collect(Collectors.toList());
+
+        if (helper.isAvailable()) {
+            updated.add(toDto(helper));
+        }
+
+        redisTemplate.opsForValue().set(HELPER_CACHE_KEY, updated, Duration.ofMinutes(5));
+    }
+
+    /**
+     * 헬퍼 캐시 DTO 변환
+     */
+    private HelperCacheDto toDto(Helper helper) {
+        return HelperCacheDto.builder()
+                .id(helper.getId())
+                .name(helper.getName())
+                .role(helper.getRole())
+                .available(helper.isAvailable())
+                .activityStatus(helper.getActivityStatus())
+                .latitude(helper.getLatitude())
+                .longitude(helper.getLongitude())
+                .trustScore(helper.getTrustScore())
+                .lastLocationUpdateTime(helper.getLastLocationUpdateTime())
+                .build();
+    }
+}


### PR DESCRIPTION
## 📌 [Feat] Redis 캐시 기반 Helper 조회 기능


---

## ✨ 작업 개요
- 응급 상황 시 빠르게 근무 가능한 Helper를 조회하기 위해 /api/helpers/available 같은 요청이 많이 들어와도 DB 부하 없이 처리할 수 있게 하였습니다.
- Helper 정보(위치, 상태 등)를 Redis 캐시에 저장합니다.
- Helper가 상태를 변경하거나 위치를 갱신할 때 Redis도 즉시 갱신할 수 있게 하였습니다.
---

## 🔨 변경 사항

---

## ✅ 체크리스트
- [x] Redis 환경 설정 완료
- [x] HelperCacheDto 설계 완료
- [x] HelperCacheService 구현
- [x] Redis TTL(유효시간) 설정 적용
- [x] HelperCacheScheduler 등록
- [x] Controller 연동
- [x] Swagger 문서화


---

## 📷 스크린샷 (선택)
<!-- UI 작업 시 스크린샷이나 API 응답 예시를 첨부하면 좋아요 -->

---

## 🔗 관련 이슈
<!-- 관련된 이슈 번호가 있다면 적어주세요 -->
- close #이슈번호