### PR TITLE
[Feat] 생필품 재고 및 상태 확인 기능 개발

### DIFF
--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/controller/DailyNecessitiesController.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/controller/DailyNecessitiesController.java
@@ -452,6 +452,15 @@ public class DailyNecessitiesController {
         return ResponseEntity.ok("현재 배송 상태는 " + delivery.getStatus() + " 입니다.");
     }
 
+    //-------------------------------
+    // 사용자 생필품 배송 상태 변경/조회 기능
+    //----------------------------------
+
+    @Operation(summary = "센터별 운영 요약", description = "센터의 생필품 재고 현황, 요청 대기, 배송 진행 건수를 요약 조회합니다.")
+    @GetMapping("/center/{centerId}/board")
+    public ResponseEntity<DailyNecessitiesCenterBoardDto> getCenterBoard(@PathVariable Long centerId) {
+        return ResponseEntity.ok(statisticsService.getCenterBoard(centerId));
+    }
 
 
 }

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/dto/DailyNecessitiesCenterBoardDto.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/dto/DailyNecessitiesCenterBoardDto.java
@@ -1,0 +1,21 @@
+package com.save_help.Save_Help.dailyNecessities.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DailyNecessitiesCenterBoardDto {
+
+    private Long centerId;           // 센터 ID
+    private String centerName;       // 센터명
+
+    private Long totalStock;         // 총 재고 수량
+    private Long lowStockCount;      // 부족 품목 수
+
+    private Long pendingRequests;    // 대기 중 요청 수
+    private Long inProgressDeliveries; // 진행 중 배송 수
+    private Long completedDeliveries;  // 완료된 배송 수
+}

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessities.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessities.java
@@ -17,7 +17,6 @@ public class DailyNecessities {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-
     // 품목명
     @Column(nullable = false, length = 100)
     private String name;

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesDeliveryRepository.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesDeliveryRepository.java
@@ -2,6 +2,16 @@ package com.save_help.Save_Help.dailyNecessities.repository;
 
 import com.save_help.Save_Help.dailyNecessities.entity.DailyNecessitiesDelivery;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface DailyNecessitiesDeliveryRepository extends JpaRepository<DailyNecessitiesDelivery, Long> {
+
+    @Query("SELECT COUNT(d) FROM DailyNecessitiesDelivery d WHERE d.center.id = :centerId AND d.status = 'IN_TRANSIT'")
+    Long countInProgressDeliveries(@Param("centerId") Long centerId);
+
+    @Query("SELECT COUNT(d) FROM DailyNecessitiesDelivery d WHERE d.center.id = :centerId AND d.status = 'DELIVERED'")
+    Long countCompletedDeliveries(@Param("centerId") Long centerId);
+
+
 }

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesRepository.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesRepository.java
@@ -3,6 +3,8 @@ package com.save_help.Save_Help.dailyNecessities.repository;
 import com.save_help.Save_Help.dailyNecessities.entity.DailyNecessities;
 import com.save_help.Save_Help.dailyNecessities.entity.NecessityCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Arrays;
@@ -36,5 +38,12 @@ public interface DailyNecessitiesRepository extends JpaRepository<DailyNecessiti
 
 
     // providedBy(CommunityCenter)의 id로 검색
+
+    //통계 쿼리
+    @Query("SELECT SUM(d.quantity) FROM DailyNecessities d WHERE d.center.id = :centerId")
+    Long findTotalStockByCenter(@Param("centerId") Long centerId);
+
+    @Query("SELECT COUNT(d) FROM DailyNecessities d WHERE d.center.id = :centerId AND d.quantity < :threshold")
+    Long findLowStockCountByCenter(@Param("centerId") Long centerId, @Param("threshold") int threshold);
 
 }

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/UserNecessityRequestRepository.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/UserNecessityRequestRepository.java
@@ -3,6 +3,8 @@ package com.save_help.Save_Help.dailyNecessities.repository;
 import com.save_help.Save_Help.dailyNecessities.entity.UserNecessityRequest;
 import com.save_help.Save_Help.dailyNecessities.entity.UserNecessityRequest.RequestStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -11,6 +13,9 @@ public interface UserNecessityRequestRepository extends JpaRepository<UserNecess
     List<UserNecessityRequest> findByStatus(RequestStatus status);
 
     List<UserNecessityRequest> findTop10ByUserIdOrderByCreatedAtDesc(Long userId);
+
+    @Query("SELECT COUNT(r) FROM UserNecessityRequest r WHERE r.item.center.id = :centerId AND r.status = 'PENDING'")
+    Long countPendingRequestsByCenter(@Param("centerId") Long centerId);
 
 
 }

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/service/DailyNecessitiesStatisticsService.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/service/DailyNecessitiesStatisticsService.java
@@ -1,10 +1,14 @@
 package com.save_help.Save_Help.dailyNecessities.service;
 
+import com.save_help.Save_Help.communityCenter.entity.CommunityCenter;
 import com.save_help.Save_Help.communityCenter.repository.CommunityCenterRepository;
+import com.save_help.Save_Help.dailyNecessities.dto.DailyNecessitiesCenterBoardDto;
 import com.save_help.Save_Help.dailyNecessities.dto.StockStatisticsDto;
 import com.save_help.Save_Help.dailyNecessities.entity.DailyNecessities;
+import com.save_help.Save_Help.dailyNecessities.repository.DailyNecessitiesDeliveryRepository;
 import com.save_help.Save_Help.dailyNecessities.repository.DailyNecessitiesRepository;
 
+import com.save_help.Save_Help.dailyNecessities.repository.UserNecessityRequestRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,11 +21,16 @@ public class DailyNecessitiesStatisticsService {
 
     private final DailyNecessitiesRepository necessitiesRepository;
     private final CommunityCenterRepository centerRepository;
+    private final UserNecessityRequestRepository requestRepository;
+    private final DailyNecessitiesDeliveryRepository deliveryRepository;
+
 
     public DailyNecessitiesStatisticsService(DailyNecessitiesRepository necessitiesRepository,
-                                             CommunityCenterRepository centerRepository) {
+                                             CommunityCenterRepository centerRepository, UserNecessityRequestRepository requestRepository, DailyNecessitiesDeliveryRepository deliveryRepository) {
         this.necessitiesRepository = necessitiesRepository;
         this.centerRepository = centerRepository;
+        this.requestRepository = requestRepository;
+        this.deliveryRepository = deliveryRepository;
     }
 
     // 🔹 센터별 재고 합계
@@ -54,4 +63,26 @@ public class DailyNecessitiesStatisticsService {
     }
 
      */
+
+    public DailyNecessitiesCenterBoardDto getCenterBoard(Long centerId) {
+        CommunityCenter center = centerRepository.findById(centerId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 센터를 찾을 수 없습니다."));
+
+        Long totalStock = necessitiesRepository.findTotalStockByCenter(centerId);
+        Long lowStockCount = necessitiesRepository.findLowStockCountByCenter(centerId, 10);
+
+        Long pendingRequests = requestRepository.countPendingRequestsByCenter(centerId);
+        Long inProgressDeliveries = deliveryRepository.countInProgressDeliveries(centerId);
+        Long completedDeliveries = deliveryRepository.countCompletedDeliveries(centerId);
+
+        return DailyNecessitiesCenterBoardDto.builder()
+                .centerId(center.getId())
+                .centerName(center.getName())
+                .totalStock(totalStock != null ? totalStock : 0)
+                .lowStockCount(lowStockCount != null ? lowStockCount : 0)
+                .pendingRequests(pendingRequests != null ? pendingRequests : 0)
+                .inProgressDeliveries(inProgressDeliveries != null ? inProgressDeliveries : 0)
+                .completedDeliveries(completedDeliveries != null ? completedDeliveries : 0)
+                .build();
+    }
 }


### PR DESCRIPTION
## 📌 [Feat] 생필품 재고 및 상태 확인 기능 개발


---

## ✨ 작업 개요
- 센터 운영 담당자를 위한 센터별 생필품 재고 상태를 확인할 수 있는 API를 개발하였습니다.
- 센터별 운영 요약 기능(getCenterBoard)을 추가하여 총 재고, 부족 품목 수, 대기 요청 수, 배송 진행 현황 등을 단일 API에서 조회할 수 있도록 구현하였습니다.
- DailyNecessitiesStatisticsService 내 getCenterBoard() 메서드를 구현하여 Repository에서 센터별 집계 데이터를 수집 및 요약 처리하였습니다.
---

## 🔨 변경 사항

---

## ✅ 체크리스트
- [x] DailyNecessitiesCenterBoardDto 생성 (필드: 재고, 요청, 배송 현황 등)
- [x] DailyNecessitiesRepository → 센터별 재고/부족 재고 쿼리 추가
- [x] UserNecessityRequestRepository → 대기 요청 수 카운트 쿼리 추가
- [x] DailyNecessitiesDeliveryRepository → 배송 상태별 카운트 쿼리 추가
- [x] DailyNecessitiesStatisticsService → getCenterboard() 구현
- [x] DailyNecessitiesController → /center/{centerId}/board 엔드포인트 추가
- [x] Swagger 문서화


---

## 📷 스크린샷 (선택)
<!-- UI 작업 시 스크린샷이나 API 응답 예시를 첨부하면 좋아요 -->

---

## 🔗 관련 이슈
<!-- 관련된 이슈 번호가 있다면 적어주세요 -->
- close #이슈번호