### PR TITLE
[Feat] 생필품 긴급 재고 알림 기능 개발

### DIFF
--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/controller/DailyNecessitiesController.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/controller/DailyNecessitiesController.java
@@ -462,5 +462,13 @@ public class DailyNecessitiesController {
         return ResponseEntity.ok(statisticsService.getCenterBoard(centerId));
     }
 
-
+    //----------------------------------------
+    // 긴급 재고 알림 기능
+    //----------------------------------------
+    @Operation(summary = "긴급 재고 알림 테스트", description = "재고 부족 시 관리자에게 알림을 발송합니다.")
+    @PostMapping("/alerts/low-stock")
+    public ResponseEntity<String> triggerLowStockAlerts() {
+        necessitiesService.alertLowStockItems();
+        return ResponseEntity.ok("긴급 재고 알림이 발송되었습니다.");
+    }
 }

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessities.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessities.java
@@ -64,6 +64,7 @@ public class DailyNecessities {
         this.active = true;
         this.approvalStatus = ApprovalStatus.PENDING;
     }
+
     public void deactivate() { this.active = false; }
 
     public void approve() {

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessitiesAlertLog.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessitiesAlertLog.java
@@ -1,0 +1,28 @@
+package com.save_help.Save_Help.dailyNecessities.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+public class DailyNecessitiesAlertLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private AlertType type;
+
+    @Column(length = 1000)
+    private String message;
+
+    private LocalDateTime createdAt;
+
+    public enum AlertType {
+        LOW_STOCK, EXPIRE_SOON, SYSTEM_ERROR
+    }
+}

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesAlertLogRepository.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesAlertLogRepository.java
@@ -1,0 +1,8 @@
+package com.save_help.Save_Help.dailyNecessities.repository;
+
+import com.save_help.Save_Help.dailyNecessities.entity.DailyNecessities;
+import com.save_help.Save_Help.dailyNecessities.entity.DailyNecessitiesAlertLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DailyNecessitiesAlertLogRepository extends JpaRepository<DailyNecessitiesAlertLog, Long> {
+}

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesRepository.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesRepository.java
@@ -46,4 +46,5 @@ public interface DailyNecessitiesRepository extends JpaRepository<DailyNecessiti
     @Query("SELECT COUNT(d) FROM DailyNecessities d WHERE d.center.id = :centerId AND d.quantity < :threshold")
     Long findLowStockCountByCenter(@Param("centerId") Long centerId, @Param("threshold") int threshold);
 
+    List<DailyNecessities> findByStockLessThan(int threshold);
 }

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/service/DailyNecessitiesAlertService.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/service/DailyNecessitiesAlertService.java
@@ -1,0 +1,55 @@
+package com.save_help.Save_Help.dailyNecessities.service;
+
+import com.save_help.Save_Help.dailyNecessities.entity.DailyNecessities;
+import com.save_help.Save_Help.dailyNecessities.entity.DailyNecessitiesAlertLog;
+import com.save_help.Save_Help.dailyNecessities.repository.DailyNecessitiesAlertLogRepository;
+import com.save_help.Save_Help.dailyNecessities.repository.DailyNecessitiesRepository;
+import com.save_help.Save_Help.messaging.service.TwilioService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DailyNecessitiesAlertService {
+
+    private final DailyNecessitiesRepository necessitiesRepository;
+    private final TwilioService twilioService;
+    private final DailyNecessitiesAlertLogRepository alertLogRepository;
+
+    private static final int LOW_STOCK_THRESHOLD = 7;
+
+    public void sendLowStockAlerts() {
+        List<DailyNecessities> lowStockItems = necessitiesRepository.findByStockLessThan(LOW_STOCK_THRESHOLD);
+
+        if (lowStockItems.isEmpty()) {
+            return;
+        }
+
+        StringBuilder messageBuilder = new StringBuilder("[긴급 재고 알림]\n");
+        for (DailyNecessities item : lowStockItems) {
+            messageBuilder.append("- ")
+                    .append(item.getName())
+                    .append(" (잔여: ")
+                    .append(item.getStock())
+                    .append(")\n");
+        }
+
+        String message = messageBuilder.toString();
+
+
+        List<String> adminPhones = List.of("", "");
+
+        for (String phone : adminPhones) {
+            twilioService.sendSms(phone, message);
+        }
+
+        // 로그 저장
+        DailyNecessitiesAlertLog log = new DailyNecessitiesAlertLog();
+        log.setMessage(message);
+        log.setType(DailyNecessitiesAlertLog.AlertType.LOW_STOCK);
+        log.setCreatedAt(LocalDateTime.now());
+        alertLogRepository.save(log);
+    }
+}


### PR DESCRIPTION
## 📌 [Feat] 생필품 긴급 재고 알림 기능 개발


---

## ✨ 작업 개요
- 생필품이 부족한 상황을 예방하기 위해 생필품 긴급 재고 관련 알림 서비스를 개발하였습니다.
- 재고 소진 전 조기 조치를 가능하게 할 수 있도록 실시간으로 대응과 센터 재고 관리 자동화 향상을 위해 개발하였습니다.
- 생필품 자동 신청, 알림 기능 등을 고도화 할 예정입니다.
---

## 🔨 변경 사항

---

## ✅ 체크리스트
- [x] DailyNecessitiesAlertService 생성 및 sendLowStockAlerts() 구현
- [x] DailyNecessitiesAlertLog 엔티티 및 JPA Repository 구현
- [x] DailyNecessitiesService에 alertLowStockItems() 추가
- [x] /api/necessities/alerts/low-stock API → Service 연결
- [x] TwilioService 연동
- [x] DailyNecessitiesAlertLog DB 저장
- [x] Swagger 문서화 및 생필품 관련 서비스 고도화 예정


---

## 📷 스크린샷 (선택)
<!-- UI 작업 시 스크린샷이나 API 응답 예시를 첨부하면 좋아요 -->

---

## 🔗 관련 이슈
<!-- 관련된 이슈 번호가 있다면 적어주세요 -->
- close #이슈번호