### PR TITLE
[Feat] 생필품 신청 관련 알림 기능 개발

### DIFF
--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/controller/DailyNecessitiesController.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/controller/DailyNecessitiesController.java
@@ -210,6 +210,7 @@ public class DailyNecessitiesController {
     // ------------------------------------
     // 관리자용 승인 / 거절
     // ------------------------------------
+
     @Operation(summary = "생필품 품목 승인이 pending된 품목들을 조회", description = "생필품 품목 승인이 pending된 품목들을 조회합니다")
     @GetMapping("/admin/pending-items")
     public ResponseEntity<List<DailyNecessities>> getPendingItems() {

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessities.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessities.java
@@ -83,4 +83,5 @@ public class DailyNecessities {
         PENDING, APPROVED, REJECTED
     }
 
+
 }

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessitiesNotification.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessitiesNotification.java
@@ -1,0 +1,37 @@
+package com.save_help.Save_Help.dailyNecessities.entity;
+
+import com.save_help.Save_Help.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+public class DailyNecessitiesNotification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 알림 대상 사용자
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private String message;
+
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Enumerated(EnumType.STRING)
+    private NotificationType type;
+
+    public enum NotificationType {
+        REQUEST_APPROVED,
+        REQUEST_REJECTED
+    }
+}

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesNotificationRepository.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesNotificationRepository.java
@@ -1,0 +1,8 @@
+package com.save_help.Save_Help.dailyNecessities.repository;
+
+import com.save_help.Save_Help.dailyNecessities.entity.DailyNecessitiesNotification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DailyNecessitiesNotificationRepository
+        extends JpaRepository<DailyNecessitiesNotification, Long> {
+}

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/service/DailyNecessitiesNotificationService.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/service/DailyNecessitiesNotificationService.java
@@ -1,5 +1,10 @@
 package com.save_help.Save_Help.dailyNecessities.service;
 
+import com.save_help.Save_Help.dailyNecessities.entity.DailyNecessities;
+import com.save_help.Save_Help.dailyNecessities.entity.DailyNecessitiesNotification;
+import com.save_help.Save_Help.dailyNecessities.entity.UserNecessityRequest;
+import com.save_help.Save_Help.dailyNecessities.repository.DailyNecessitiesNotificationRepository;
+import com.save_help.Save_Help.user.entity.User;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -7,6 +12,35 @@ import org.springframework.stereotype.Service;
 @Service
 public class DailyNecessitiesNotificationService {
 
+    private final DailyNecessitiesNotificationRepository notificationRepository;
+
+    public DailyNecessitiesNotificationService(DailyNecessitiesNotificationRepository notificationRepository) {
+        this.notificationRepository = notificationRepository;
+    }
+
+    public void sendRequestStatusNotification(User user, DailyNecessities item,
+                                              UserNecessityRequest.RequestStatus status) {
+
+        String message;
+
+        if (status == UserNecessityRequest.RequestStatus.APPROVED) {
+            message = String.format("'%s' 생필품 신청이 승인되었습니다.", item.getName());
+        } else {
+            message = String.format("'%s' 생필품 신청이 보류되었습니다.", item.getName());
+        }
+
+        DailyNecessitiesNotification notification = new DailyNecessitiesNotification();
+        notification.setUser(user);
+        notification.setMessage(message);
+
+        notification.setType(
+                status == UserNecessityRequest.RequestStatus.APPROVED ?
+                        DailyNecessitiesNotification.NotificationType.REQUEST_APPROVED :
+                        DailyNecessitiesNotification.NotificationType.REQUEST_REJECTED
+        );
+
+        notificationRepository.save(notification);
+    }
     //임시
     public void notifyUser(Long userId, String message) {
         log.info("[USER {} 알림] {}", userId, message);

--- a/src/main/java/com/save_help/Save_Help/helper/dto/AdminNoticeRequestDto.java
+++ b/src/main/java/com/save_help/Save_Help/helper/dto/AdminNoticeRequestDto.java
@@ -1,0 +1,18 @@
+package com.save_help.Save_Help.helper.dto;
+
+import com.save_help.Save_Help.helper.entity.HelperRole;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AdminNoticeRequestDto {
+
+    private String title;       // 공지 제목
+    private String message;     // 공지 내용
+
+    private HelperRole role;    // 특정 역할 대상 (선택)
+    private Long centerId;      // 특정 센터 대상 (선택)
+
+    private boolean sendToAll;  // 전체 헬퍼에게 발송할지 여부
+}

--- a/src/main/java/com/save_help/Save_Help/helper/entity/NotificationType.java
+++ b/src/main/java/com/save_help/Save_Help/helper/entity/NotificationType.java
@@ -1,0 +1,8 @@
+package com.save_help.Save_Help.helper.entity;
+
+public enum NotificationType {
+    REVIEW,
+    EMERGENCY,
+    SYSTEM,
+    ADMIN_NOTICE
+}


### PR DESCRIPTION
## 📌 [Feat] 생필품 신청 관련 알림 기능 개발


---

## ✨ 작업 개요
- 생필품 신청과 관련하여 사용자에게 자동으로 알림이 전달되는 기능을 구현했습니다.
- 알림 엔티티 및 저장용 Repository, 알림 전송 서비스 로직을 추가하였습니다.
- 신청 상태 변경 API 호출 시 알림이 자동으로 생성되도록 연계하여 사용자 경험을 개선했습니다. 앞으로 계속해서 생필품 관련하여 기능을 개선하고 고도해나갈 예정입니다.
---

## 🔨 변경 사항

---

## ✅ 체크리스트
- [x] DailyNecessitiesNotification 엔티티 및 Repository 구현
- [x] 알림 전송 로직(DailyNecessitiesNotificationService) 추가
- [x] 메시지 포맷 정의 및 타입(NotificationType) 추가
- [x] 알림 생성 시 사용자 및 생필품 정보 매핑 처리
- [x] UserNecessityRequestService.updateRequestStatus 내부에 알림 연동
- [x] 기존 신청 상태 변경 API 연동
- [x] Swagger 문서화



---

## 📷 스크린샷 (선택)
<!-- UI 작업 시 스크린샷이나 API 응답 예시를 첨부하면 좋아요 -->

---

## 🔗 관련 이슈
<!-- 관련된 이슈 번호가 있다면 적어주세요 -->
- close #이슈번호