### PR TITLE
[Feat] Emergency 상태/조건 조회, 페이징 정렬 기능 개발

### DIFF
--- a/src/main/java/com/save_help/Save_Help/emergency/controller/EmergencyController.java
+++ b/src/main/java/com/save_help/Save_Help/emergency/controller/EmergencyController.java
@@ -1,12 +1,12 @@
 package com.save_help.Save_Help.emergency.controller;
 
-import com.save_help.Save_Help.emergency.dto.EmergencyRequestDto;
-import com.save_help.Save_Help.emergency.dto.EmergencyResponseDto;
-import com.save_help.Save_Help.emergency.dto.EmergencyVoiceCreateRequestDto;
-import com.save_help.Save_Help.emergency.dto.EmergencyVoiceCreateResponseDto;
+import com.save_help.Save_Help.emergency.dto.*;
+import com.save_help.Save_Help.emergency.entity.EmergencyStatus;
 import com.save_help.Save_Help.emergency.service.EmergencyService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -62,4 +62,43 @@ public class EmergencyController {
     ) {
         return ResponseEntity.ok(emergencyService.createEmergencyByVoice(req));
     }
+
+    @GetMapping("/search")
+    @Operation(summary = "긴급 요청 조회(필터/페이징/정렬)", description = "status, 미해결, 취소 제외, 최근 N시간 필터와 함께 조회합니다.")
+    public ResponseEntity<Page<EmergencyResponseDto>> search(
+            @RequestParam(required = false) EmergencyStatus status,
+            @RequestParam(required = false) Boolean unresolvedOnly,
+            @RequestParam(required = false) Boolean excludeCancelled,
+            @RequestParam(required = false) Integer recentHours,
+            Pageable pageable
+    ) {
+        return ResponseEntity.ok(emergencyService.search(status, unresolvedOnly, excludeCancelled, recentHours, pageable));
+    }
+
+
+    @PutMapping("/{id}/accept")
+    @Operation(summary = "긴급 요청 접수", description = "헬퍼가 긴급 요청을 접수합니다.")
+    public ResponseEntity<EmergencyResponseDto> accept(
+            @PathVariable Long id,
+            @RequestBody EmergencyAcceptRequestDto req
+    ) {
+        return ResponseEntity.ok(emergencyService.accept(id, req.helperId()));
+    }
+
+    @PutMapping("/{id}/assign")
+    @Operation(summary = "긴급 요청 배치", description = "관리자/센터가 헬퍼를 긴급 요청에 배치합니다.")
+    public ResponseEntity<EmergencyResponseDto> assign(
+            @PathVariable Long id,
+            @RequestBody EmergencyAssignRequestDto req
+    ) {
+        return ResponseEntity.ok(emergencyService.assign(id, req.helperId()));
+    }
+
+    @PutMapping("/{id}/progress")
+    @Operation(summary = "긴급 요청 진행 시작", description = "접수/배정된 긴급 요청을 진행 상태로 변경합니다.")
+    public ResponseEntity<EmergencyResponseDto> startProgress(@PathVariable Long id) {
+        return ResponseEntity.ok(emergencyService.startProgress(id));
+    }
+
+
 }

--- a/src/main/java/com/save_help/Save_Help/emergency/dto/EmergencyAcceptRequestDto.java
+++ b/src/main/java/com/save_help/Save_Help/emergency/dto/EmergencyAcceptRequestDto.java
@@ -1,0 +1,8 @@
+package com.save_help.Save_Help.emergency.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record EmergencyAcceptRequestDto (
+    @NotNull(message = "helperId는 필수입니다.")
+    Long helperId
+){}

--- a/src/main/java/com/save_help/Save_Help/emergency/dto/EmergencyAssignRequestDto.java
+++ b/src/main/java/com/save_help/Save_Help/emergency/dto/EmergencyAssignRequestDto.java
@@ -1,0 +1,8 @@
+package com.save_help.Save_Help.emergency.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record EmergencyAssignRequestDto(
+    @NotNull(message = "helperId는 필수입니다.")
+    Long helperId
+){}

--- a/src/main/java/com/save_help/Save_Help/emergency/dto/EmergencyResponseDto.java
+++ b/src/main/java/com/save_help/Save_Help/emergency/dto/EmergencyResponseDto.java
@@ -1,5 +1,6 @@
 package com.save_help.Save_Help.emergency.dto;
 
+import com.save_help.Save_Help.emergency.entity.Emergency;
 import com.save_help.Save_Help.emergency.entity.EmergencyStatus;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,4 +18,21 @@ public class EmergencyResponseDto {
     private EmergencyStatus status;
     private LocalDateTime requestedAt;
     private LocalDateTime resolvedAt;
+
+    public static EmergencyResponseDto from(Emergency emergency) {
+        return EmergencyResponseDto.builder()
+                .id(emergency.getId())
+                .userId(
+                        emergency.getRequester() != null
+                                ? emergency.getRequester().getId()
+                                : null
+                )
+                .description(emergency.getDescription())
+                .latitude(emergency.getLatitude())
+                .longitude(emergency.getLongitude())
+                .status(emergency.getStatus())
+                .requestedAt(emergency.getRequestedAt())
+                .resolvedAt(emergency.getResolvedAt())
+                .build();
+    }
 }

--- a/src/main/java/com/save_help/Save_Help/emergency/entity/Emergency.java
+++ b/src/main/java/com/save_help/Save_Help/emergency/entity/Emergency.java
@@ -40,14 +40,14 @@ public class Emergency {
 
     private LocalDateTime requestedAt;
 
-    @Column(name = "resolved_at", nullable = false)
+    @Column(name = "resolved_at")
     private LocalDateTime resolvedAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "helper_id")
     private Helper assignedHelper;
 
-
+/*
     public void markResolved() {
         this.status = EmergencyStatus.RESOLVED;
         this.resolvedAt = LocalDateTime.now();
@@ -57,7 +57,7 @@ public class Emergency {
         this.status = EmergencyStatus.CANCELLED;
         this.resolvedAt = LocalDateTime.now();
     }
-
+*/
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "hospital_id")
     private Hospital hospital; // 해당 병원으로 배정
@@ -73,4 +73,53 @@ public class Emergency {
     //(긴급도)
     @Enumerated(EnumType.STRING)
     private EmergencySeverity severity;
+
+    /** 헬퍼가 긴급 요청을 접수 */
+    public void accept(Helper helper) {
+        if (this.status != EmergencyStatus.REQUESTED) {
+            throw new IllegalStateException("CREATED 상태에서만 접수할 수 있습니다.");
+        }
+        this.assignedHelper = helper;
+        this.status = EmergencyStatus.ACCEPTED;
+    }
+
+    /** 관리자/센터가 헬퍼를 수동 배치 */
+    public void assign(Helper helper) {
+        if (this.status == EmergencyStatus.RESOLVED ||
+                this.status == EmergencyStatus.CANCELLED) {
+            throw new IllegalStateException("종료된 요청은 배치할 수 없습니다.");
+        }
+        this.assignedHelper = helper;
+        this.status = EmergencyStatus.ASSIGNED;
+    }
+
+    /** 실제 대응 시작 */
+    public void startProgress() {
+        if (this.status != EmergencyStatus.ACCEPTED &&
+                this.status != EmergencyStatus.ASSIGNED) {
+            throw new IllegalStateException("ACCEPTED 또는 ASSIGNED 상태에서만 진행할 수 있습니다.");
+        }
+        this.status = EmergencyStatus.IN_PROGRESS;
+    }
+
+    /** 해결 완료 */
+    public void markResolved() {
+        if (this.status == EmergencyStatus.CANCELLED) {
+            throw new IllegalStateException("취소된 요청은 해결 처리할 수 없습니다.");
+        }
+        this.status = EmergencyStatus.RESOLVED;
+        this.resolvedAt = LocalDateTime.now();
+        this.resolved = true;
+    }
+
+    /** 요청 취소 */
+    public void cancel() {
+        if (this.status == EmergencyStatus.RESOLVED) {
+            throw new IllegalStateException("이미 해결된 요청은 취소할 수 없습니다.");
+        }
+        this.status = EmergencyStatus.CANCELLED;
+        this.resolvedAt = LocalDateTime.now();
+        this.resolved = false;
+    }
+
 }

--- a/src/main/java/com/save_help/Save_Help/emergency/entity/EmergencyStatus.java
+++ b/src/main/java/com/save_help/Save_Help/emergency/entity/EmergencyStatus.java
@@ -6,5 +6,6 @@ public enum EmergencyStatus {
     ASSIGNED,    // 헬퍼나 병원에 배정됨
     IN_PROGRESS,// 처리 중
     RESOLVED,   // 처리 완료
-    CANCELLED   // 사용자 취소
+    CANCELLED,   // 사용자 취소
+    ACCEPTED
 }

--- a/src/main/java/com/save_help/Save_Help/emergency/filter/EmergencySpecs.java
+++ b/src/main/java/com/save_help/Save_Help/emergency/filter/EmergencySpecs.java
@@ -1,0 +1,38 @@
+package com.save_help.Save_Help.emergency.filter;
+
+import com.save_help.Save_Help.emergency.entity.Emergency;
+import com.save_help.Save_Help.emergency.entity.EmergencyStatus;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.LocalDateTime;
+
+public class EmergencySpecs {
+
+    public static Specification<Emergency> status(EmergencyStatus status) {
+        return (root, query, cb) -> status == null ? null : cb.equal(root.get("status"), status);
+    }
+
+    public static Specification<Emergency> excludeCancelled(Boolean exclude) {
+        return (root, query, cb) -> (exclude != null && exclude)
+                ? cb.notEqual(root.get("status"), EmergencyStatus.CANCELLED)
+                : null;
+    }
+
+    public static Specification<Emergency> unresolvedOnly(Boolean unresolvedOnly) {
+        // "미해결만" = RESOLVED 제외 + CANCELLED 제외
+        return (root, query, cb) -> (unresolvedOnly != null && unresolvedOnly)
+                ? cb.and(
+                cb.notEqual(root.get("status"), EmergencyStatus.RESOLVED),
+                cb.notEqual(root.get("status"), EmergencyStatus.CANCELLED)
+        )
+                : null;
+    }
+
+    public static Specification<Emergency> requestedWithinHours(Integer hours) {
+        return (root, query, cb) -> {
+            if (hours == null) return null;
+            LocalDateTime from = LocalDateTime.now().minusHours(hours);
+            return cb.greaterThanOrEqualTo(root.get("requestedAt"), from);
+        };
+    }
+}

--- a/src/main/java/com/save_help/Save_Help/emergency/repository/EmergencyRepository.java
+++ b/src/main/java/com/save_help/Save_Help/emergency/repository/EmergencyRepository.java
@@ -3,14 +3,25 @@ package com.save_help.Save_Help.emergency.repository;
 import com.save_help.Save_Help.emergency.entity.Emergency;
 import com.save_help.Save_Help.emergency.entity.EmergencyStatus;
 import com.save_help.Save_Help.user.entity.User;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
-public interface EmergencyRepository extends JpaRepository<Emergency, Long> {
+public interface EmergencyRepository extends JpaRepository<Emergency, Long>, JpaSpecificationExecutor<Emergency> {
     List<Emergency> findByRequester(User requester);
 
     List<Emergency> findByAssignedHelperIsNullAndResolvedFalse();
 
     List<Emergency> findByAssignedHelperIsNullAndStatusIn(List<EmergencyStatus> statuses);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select e from Emergency e where e.id = :id")
+    Optional<Emergency> findByIdForUpdate(@Param("id") Long id);
+
 }

--- a/src/main/java/com/save_help/Save_Help/emergency/service/EmergencyService.java
+++ b/src/main/java/com/save_help/Save_Help/emergency/service/EmergencyService.java
@@ -6,12 +6,18 @@ import com.save_help.Save_Help.emergency.dto.EmergencyResponseDto;
 import com.save_help.Save_Help.emergency.dto.EmergencyVoiceCreateRequestDto;
 import com.save_help.Save_Help.emergency.dto.EmergencyVoiceCreateResponseDto;
 import com.save_help.Save_Help.emergency.entity.*;
+import com.save_help.Save_Help.emergency.filter.EmergencySpecs;
 import com.save_help.Save_Help.emergency.repository.EmergencyRepository;
 import com.save_help.Save_Help.emergency.repository.EmergencyVoiceNoteRepository;
+import com.save_help.Save_Help.helper.entity.Helper;
+import com.save_help.Save_Help.helper.repository.HelperRepository;
 import com.save_help.Save_Help.user.entity.User;
 import com.save_help.Save_Help.user.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -27,6 +33,7 @@ public class EmergencyService {
     private final EmergencyRepository emergencyRepository;
     private final EmergencyVoiceNoteRepository voiceNoteRepository;
     private final UserRepository userRepository;
+    private final HelperRepository helperRepository;
 
     // 긴급 요청 생성
     public EmergencyResponseDto createEmergency(EmergencyRequestDto dto) {
@@ -60,6 +67,7 @@ public class EmergencyService {
     }
 
     // 요청 취소
+    /*
     public EmergencyResponseDto cancelEmergency(Long id) {
         Emergency emergency = emergencyRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 요청을 찾을 수 없습니다."));
@@ -74,6 +82,8 @@ public class EmergencyService {
         emergency.markResolved();
         return toResponseDto(emergencyRepository.save(emergency));
     }
+
+     */
 
     private EmergencyResponseDto toResponseDto(Emergency e) {
         return EmergencyResponseDto.builder()
@@ -147,5 +157,73 @@ public class EmergencyService {
         if (s == null) return null;
         return s.trim().replaceAll("\\s+", " ");
     }
+
+    // 페이징 정렬
+    @Transactional(readOnly = true)
+    public Page<EmergencyResponseDto> search(
+            EmergencyStatus status,
+            Boolean unresolvedOnly,
+            Boolean excludeCancelled,
+            Integer recentHours,
+            Pageable pageable
+    ) {
+        Specification<Emergency> spec = Specification.where(EmergencySpecs.status(status))
+                .and(EmergencySpecs.unresolvedOnly(unresolvedOnly))
+                .and(EmergencySpecs.excludeCancelled(excludeCancelled))
+                .and(EmergencySpecs.requestedWithinHours(recentHours));
+
+        return emergencyRepository.findAll(spec, pageable)
+                .map(EmergencyResponseDto::from);
+    }
+
+    // 헬퍼가 접수
+    public EmergencyResponseDto accept(Long emergencyId, Long helperId) {
+        Emergency emergency = emergencyRepository.findByIdForUpdate(emergencyId)
+                .orElseThrow(() -> new EntityNotFoundException("Emergency not found: " + emergencyId));
+
+        Helper helper = helperRepository.findById(helperId)
+                .orElseThrow(() -> new EntityNotFoundException("Helper not found: " + helperId));
+
+        emergency.accept(helper);
+        return EmergencyResponseDto.from(emergency);
+    }
+
+    // 관리자/센터가 배치(수동)
+    public EmergencyResponseDto assign(Long emergencyId, Long helperId) {
+        Emergency emergency = emergencyRepository.findByIdForUpdate(emergencyId)
+                .orElseThrow(() -> new EntityNotFoundException("Emergency not found: " + emergencyId));
+
+        Helper helper = helperRepository.findById(helperId)
+                .orElseThrow(() -> new EntityNotFoundException("Helper not found: " + helperId));
+
+        emergency.assign(helper);
+        return EmergencyResponseDto.from(emergency);
+    }
+
+    // 진행 시작
+    public EmergencyResponseDto startProgress(Long emergencyId) {
+        Emergency emergency = emergencyRepository.findByIdForUpdate(emergencyId)
+                .orElseThrow(() -> new EntityNotFoundException("Emergency not found: " + emergencyId));
+
+        emergency.startProgress();
+        return EmergencyResponseDto.from(emergency);
+    }
+
+    // 해결
+    public EmergencyResponseDto resolveEmergency(Long id) {
+        Emergency emergency = emergencyRepository.findByIdForUpdate(id)
+                .orElseThrow(() -> new EntityNotFoundException("Emergency not found: " + id));
+        emergency.markResolved();
+        return EmergencyResponseDto.from(emergency);
+    }
+
+    // 취소
+    public EmergencyResponseDto cancelEmergency(Long id) {
+        Emergency emergency = emergencyRepository.findByIdForUpdate(id)
+                .orElseThrow(() -> new EntityNotFoundException("Emergency not found: " + id));
+        emergency.cancel();
+        return EmergencyResponseDto.from(emergency);
+    }
+
 }
 


### PR DESCRIPTION
## 📌 [Feat] Emergency 상태/조건 조회, 페이징 정렬 기능 개발

---

## ✨ 작업 개요
- Emergency 엔티티를 개선하고 상태(Enum)를 확장하였습니다.
- Emergency 엔티티에 상태 전이 메서드를 추가하였습니다.
- 조회 필터와 페이징/정렬 기능을 개발하였습니다.
---

## 🔨 변경 사항

---

## ✅ 체크리스트
- [x] resolvedAt 필드 nullable=false
- [x] EmergencyStatus에 ACCEPTED 추가
- [x] Emergency 엔티티에 accept, assign, startProgress,markResolved, cancel 메서드 추가
- [x] JpaSpecificationExecutor 추가
- [x] 조회 필터 EmergencySpecs 생성
- [x] EmergencyController에 조회 필터와 페이징/정렬 기능, 긴급요청 처리 기능 추가



---

## 📷 스크린샷 (선택)
<!-- UI 작업 시 스크린샷이나 API 응답 예시를 첨부하면 좋아요 -->

---

## 🔗 관련 이슈
<!-- 관련된 이슈 번호가 있다면 적어주세요 -->
- close #이슈번호