### PR TITLE
[Feat] 보조금 엔티티 컬럼 업데이트

### DIFF
--- a/src/main/java/com/save_help/Save_Help/nationalSubsidy/entity/NationalSubsidy.java
+++ b/src/main/java/com/save_help/Save_Help/nationalSubsidy/entity/NationalSubsidy.java
@@ -49,5 +49,14 @@ public class NationalSubsidy {
     private Boolean disabilityRequired;
     private Boolean emergencyOnly;
 
-
+    //공공데이터
+    private String baseDate;          //기준일자
+    private String policyAreaCode;    // 분야 코드
+    private String policyAreaName;    // 분야명
+    private String categoryCode;      // 부문 코드
+    private String categoryName;      // 부문명
+    private int fiscalYear;           // 사업연도
+    private long currentBudgetAmount; // 현행 예산액
+    private long originalBudgetAmount; // 기정 예산액
+    private long executedAmount;      // 집행 금액
 }


### PR DESCRIPTION
## 📌 [Feat] 보조금 엔티티 컬럼 업데이트

---

## ✨ 작업 개요
- 보조금 엔티티인 NationalSubsidy 엔티티의 컬럼을 공공데이터 API에 맞춰 업데이트 하였습니다.
- 데이터 기준날짜, 분야명, 부문 코드, 부문명, 사업연도, 현행 예산액, 지출금액 등의 컬럼을 추가하였습니다.
- 공공데이터API에서 제공하는 보조금에 대한 컬럼들로 보조금 자동 신청 서비스를 업데이트 할 예정입니다.
---

## 🔨 변경 사항

---

## ✅ 체크리스트
- [x] 기준 날짜 컬럼 baseDate 추가
- [x] 분야 코드 policyAreaCode 추가
- [x] 분야명 policyAreaName 추가
- [x] 부문명 categoryName 추가
- [x] 사업연도 fiscalYear 추가
- [x] 현행 예산액(확정된 전체 예산) currentBudgetAmount 추가
- [x] 지출 금액(실제 집행된 금액) executedAmount 추가


---

## 📷 스크린샷 (선택)
<!-- UI 작업 시 스크린샷이나 API 응답 예시를 첨부하면 좋아요 -->

---

## 🔗 관련 이슈
<!-- 관련된 이슈 번호가 있다면 적어주세요 -->
- close #이슈번호