### PR TITLE
[Feat] 생필품 관련 시간 알림 서비스 개발

### DIFF
--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/controller/DailyNecessitiesController.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/controller/DailyNecessitiesController.java
@@ -33,7 +33,7 @@ public class DailyNecessitiesController {
     private final DailyNecessitiesDonationPointHistoryRepository historyRepository;
     private final DailyNecessitiesDeliveryService deliveryService;
     private final DailyNecessitiesNotificationService necessitiesNotificationService;
-
+    private final DailyNecessitiesSubscriptionService subscriptionService;
 
 
     public DailyNecessitiesController(
@@ -42,7 +42,7 @@ public class DailyNecessitiesController {
             DailyNecessitiesStockService stockService,
             DailyNecessitiesStatisticsService statisticsService,
             DailyNecessitiesReportService reportService,
-            DailyNecessitiesDonationService donationService, DailyNecessitiesCenterMessageService messageService, DailyNecessitiesUserRequestMessageService userRequestMessageService, DailyNecessitiesRestockForecastService restockForecastService, DailyNecessitiesAutoReorderService dailyNecessitiesAutoReorderService, UserRepository userRepository, DailyNecessitiesDonationPointHistoryRepository historyRepository, DailyNecessitiesDeliveryService deliveryService, DailyNecessitiesNotificationService necessitiesNotificationService) {
+            DailyNecessitiesDonationService donationService, DailyNecessitiesCenterMessageService messageService, DailyNecessitiesUserRequestMessageService userRequestMessageService, DailyNecessitiesRestockForecastService restockForecastService, DailyNecessitiesAutoReorderService dailyNecessitiesAutoReorderService, UserRepository userRepository, DailyNecessitiesDonationPointHistoryRepository historyRepository, DailyNecessitiesDeliveryService deliveryService, DailyNecessitiesNotificationService necessitiesNotificationService, DailyNecessitiesSubscriptionService subscriptionService) {
         this.necessitiesService = necessitiesService;
         this.requestService = requestService;
         this.stockService = stockService;
@@ -57,6 +57,7 @@ public class DailyNecessitiesController {
         this.historyRepository = historyRepository;
         this.deliveryService = deliveryService;
         this.necessitiesNotificationService = necessitiesNotificationService;
+        this.subscriptionService = subscriptionService;
     }
 
     // ------------------------------------
@@ -569,6 +570,31 @@ public class DailyNecessitiesController {
     @GetMapping("/available")
     public ResponseEntity<List<DailyNecessitiesDto>> getAvailableItems() {
         return ResponseEntity.ok(necessitiesService.getAvailableItems());
+    }
+
+    @Operation(summary = "특정 생필품 알림 구독")
+    @PostMapping("/necessity")
+    public ResponseEntity<DailyNecessitiesSubscription> subscribeNecessity(
+            @RequestParam Long userId,
+            @RequestParam Long necessityId
+    ) {
+        return ResponseEntity.ok(subscriptionService.subscribeNecessity(userId, necessityId));
+    }
+
+    @Operation(summary = "생필품 카테고리 알림 구독")
+    @PostMapping("/category")
+    public ResponseEntity<DailyNecessitiesSubscription> subscribeCategory(
+            @RequestParam Long userId,
+            @RequestParam DailyNecessitiesCategory category
+    ) {
+        return ResponseEntity.ok(subscriptionService.subscribeCategory(userId, category));
+    }
+
+    @Operation(summary = "생필품 알림 구독 해제")
+    @DeleteMapping("/{subscriptionId}")
+    public ResponseEntity<Void> unsubscribe(@PathVariable Long subscriptionId) {
+        subscriptionService.unsubscribe(subscriptionId);
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/dto/DailyNecessitiesUpdateRequest.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/dto/DailyNecessitiesUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.save_help.Save_Help.dailyNecessities.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class DailyNecessitiesUpdateRequest {
+    private String name;
+    private Integer stock;
+    private String status;
+    private Integer price;
+}

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessitiesCategory.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessitiesCategory.java
@@ -9,5 +9,6 @@ public enum DailyNecessitiesCategory {
     SCHOOL_SUPPLIES, // 학용품
     ELECTRONICS, // 생활 전자
     CARE, // 돌봄 용품
+    PET, // 반려동물용품
     OTHER       // 기타
 }

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessitiesSubscription.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessitiesSubscription.java
@@ -1,0 +1,72 @@
+package com.save_help.Save_Help.dailyNecessities.entity;
+
+import com.save_help.Save_Help.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "daily_necessities_subscription")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DailyNecessitiesSubscription {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 구독한 사용자
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // 특정 생필품을 구독하는 경우
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "necessity_id")
+    private DailyNecessities necessity;
+
+    // 카테고리 단위 구독
+    @Enumerated(EnumType.STRING)
+    @Column(length = 50)
+    private DailyNecessitiesCategory category;
+
+    // 재입고 알림 여부
+    @Builder.Default
+    private Boolean notifyOnRestock = true;
+
+    // 상태 변경 알림 여부
+    @Builder.Default
+    private Boolean notifyOnStatusChange = true;
+
+    // 가격 변경 알림 여부
+    @Builder.Default
+    private Boolean notifyOnPriceChange = false;
+
+    @Builder.Default
+    private Boolean active = true;
+
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+        if (active == null) {
+            active = true;
+        }
+        if (notifyOnRestock == null) {
+            notifyOnRestock = true;
+        }
+        if (notifyOnStatusChange == null) {
+            notifyOnStatusChange = true;
+        }
+        if (notifyOnPriceChange == null) {
+            notifyOnPriceChange = false;
+        }
+    }
+}

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesSubscriptionRepository.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesSubscriptionRepository.java
@@ -1,0 +1,22 @@
+package com.save_help.Save_Help.dailyNecessities.repository;
+
+import com.save_help.Save_Help.dailyNecessities.entity.DailyNecessities;
+import com.save_help.Save_Help.dailyNecessities.entity.DailyNecessitiesCategory;
+import com.save_help.Save_Help.dailyNecessities.entity.DailyNecessitiesSubscription;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface DailyNecessitiesSubscriptionRepository extends JpaRepository<DailyNecessitiesSubscription, Long> {
+
+    List<DailyNecessitiesSubscription> findByNecessityAndActiveTrue(DailyNecessities necessity);
+
+    List<DailyNecessitiesSubscription> findByCategoryAndActiveTrue(DailyNecessitiesCategory category);
+
+    List<DailyNecessitiesSubscription> findByUserIdAndActiveTrue(Long userId);
+
+    Optional<DailyNecessitiesSubscription> findByUserIdAndNecessityIdAndActiveTrue(Long userId, Long necessityId);
+
+    Optional<DailyNecessitiesSubscription> findByUserIdAndCategoryAndActiveTrue(Long userId, DailyNecessitiesCategory category);
+}

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/service/DailyNecessitiesSubscriptionService.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/service/DailyNecessitiesSubscriptionService.java
@@ -1,0 +1,73 @@
+package com.save_help.Save_Help.dailyNecessities.service;
+
+import com.save_help.Save_Help.dailyNecessities.entity.*;
+import com.save_help.Save_Help.dailyNecessities.repository.DailyNecessitiesRepository;
+import com.save_help.Save_Help.dailyNecessities.repository.DailyNecessitiesSubscriptionRepository;
+import com.save_help.Save_Help.user.entity.User;
+import com.save_help.Save_Help.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DailyNecessitiesSubscriptionService {
+
+    private final DailyNecessitiesSubscriptionRepository subscriptionRepository;
+    private final DailyNecessitiesRepository necessitiesRepository;
+    private final UserRepository userRepository;
+
+    public DailyNecessitiesSubscription subscribeNecessity(Long userId, Long necessityId) {
+        subscriptionRepository.findByUserIdAndNecessityIdAndActiveTrue(userId, necessityId)
+                .ifPresent(subscription -> {
+                    throw new IllegalStateException("이미 해당 생필품 알림을 구독 중입니다.");
+                });
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        DailyNecessities necessity = necessitiesRepository.findById(necessityId)
+                .orElseThrow(() -> new IllegalArgumentException("생필품을 찾을 수 없습니다."));
+
+        return subscriptionRepository.save(
+                DailyNecessitiesSubscription.builder()
+                        .user(user)
+                        .necessity(necessity)
+                        .category(null)
+                        .notifyOnRestock(true)
+                        .notifyOnStatusChange(true)
+                        .notifyOnPriceChange(false)
+                        .active(true)
+                        .build()
+        );
+    }
+
+    public DailyNecessitiesSubscription subscribeCategory(Long userId, DailyNecessitiesCategory category) {
+        subscriptionRepository.findByUserIdAndCategoryAndActiveTrue(userId, category)
+                .ifPresent(subscription -> {
+                    throw new IllegalStateException("이미 해당 카테고리 알림을 구독 중입니다.");
+                });
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        return subscriptionRepository.save(
+                DailyNecessitiesSubscription.builder()
+                        .user(user)
+                        .category(category)
+                        .necessity(null)
+                        .notifyOnRestock(true)
+                        .notifyOnStatusChange(true)
+                        .notifyOnPriceChange(false)
+                        .active(true)
+                        .build()
+        );
+    }
+
+    public void unsubscribe(Long subscriptionId) {
+        DailyNecessitiesSubscription subscription = subscriptionRepository.findById(subscriptionId)
+                .orElseThrow(() -> new IllegalArgumentException("구독 정보를 찾을 수 없습니다."));
+        subscription.setActive(false);
+    }
+}

--- a/src/main/java/com/save_help/Save_Help/nationalSubsidy/kafka/topic/KafkaTopics.java
+++ b/src/main/java/com/save_help/Save_Help/nationalSubsidy/kafka/topic/KafkaTopics.java
@@ -66,4 +66,13 @@ public final class KafkaTopics {
     public static final String SUBSIDY_UPDATED = "subsidy.updated.v1";
     public static final String SUBSIDY_APPLICATION_SUBMITTED = "subsidy.application.submitted.v1";
     public static final String SUBSIDY_APPLICATION_APPROVED = "subsidy.application.approved.v1";
+
+    public static final String DAILY_NECESSITY_NOTIFICATION_REQUESTED =
+            "dailynecessity.notification.requested.v1";
+
+    public static final String DAILY_NECESSITY_NOTIFICATION_SENT =
+            "dailynecessity.notification.sent.v1";
+
+    public static final String DAILY_NECESSITY_NOTIFICATION_FAILED =
+            "dailynecessity.notification.failed.v1";
 }


### PR DESCRIPTION
## 📌 [Feat] 생필품 관련 시간 알림 서비스 개발

---

## ✨ 작업 개요
- 생필품 관련 예약 및 배송 시간 알림 서비스 등을 개발하였습니다. 사용자가 생필품에 대해서 간간이 직접 클릭해서 확인하는 서비스에서 특정한 시간 때 부터는 생필품 업데이트 기능들을 알려주는 서비스를 개발하였습니다. 예를들어 사용자가 특정한 시간 때(예시: 2025년도 8월 중순(10일?11일 등) 등 시간을 설정해 놓으면 그 이후부터는 생필품이 업데이트 될 때 자동적으로 알려주고 신청되는 기능을 개발하였습니다.
- 생필품과 관련해서 추가적인 구현등 필요한 게 있으면 코드를 더 작성할 예정입니다. 놓친 게 있는 것 같아 개발하여 업데이트가 늦었지만 다음부터는 정확한 시간에 맞춰 PR 작성 및 커밋을 올릴 예정입니다.
- Kafka를 사용해서 개발을 끊임없이 진행하고 있고 변함없이 소중한 Kafka를 사용한 서비스를 개발할 예정입니다.

 
---

## 🔨 변경 사항

---

## ✅ 체크리스트
- [x] DailyNecessitiesSubscription 코드 작성
- [x] DailyNecessitiesCategory 작성
- [x] DailyNecessitiesUpdateRequest 작성 
- [x] DailyNecessitiesSubscriptionService 작성
- [x] DailyNecessitiesController  작성
- [x] Kafka를 사용한 코드 구현
- [x] 생필품 관련 업데이트 기능 시간 개발
---

## 📷 스크린샷 (선택)
<!-- UI 작업 시 스크린샷이나 API 응답 예시를 첨부하면 좋아요 -->

---

## 🔗 관련 이슈
<!-- 관련된 이슈 번호가 있다면 적어주세요 -->
- close #이슈번호