### PR TITLE
[Feat] Kafka에 대한 수의 저장에 대한 PR 작성

### DIFF
--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessities.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessities.java
@@ -153,5 +153,13 @@ public class DailyNecessities {
         return started && notEnded;
     }
 
+    public boolean canAutoApply() {
+        return active
+                && approvalStatus == ApprovalStatus.APPROVED
+                && stock != null
+                && stock > 0
+                && !isExpired()
+                && isWithinApplyPeriod();
+    }
 
 }

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessityApplication.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessityApplication.java
@@ -52,5 +52,11 @@ public class DailyNecessityApplication {
         REJECTED
     }
 
+    public boolean isAutoApplication() {
+        return "AUTO".equals(this.applyType);
+    }
 
+    public boolean isPending() {
+        return "PENDING".equals(this.status);
+    }
 }

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesRepository.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesRepository.java
@@ -138,4 +138,19 @@ public interface DailyNecessitiesRepository extends JpaRepository<DailyNecessiti
             DailyNecessities.ApprovalStatus approvalStatus,
             Integer stock
     );
+
+    // 자동신청 가능한 생필품 조회
+    @Query("""
+    SELECT d
+    FROM DailyNecessities d
+    WHERE d.active = true
+      AND d.approvalStatus = com.save_help.Save_Help.dailyNecessities.entity.DailyNecessities.ApprovalStatus.APPROVED
+      AND d.stock > 0
+      AND (:centerId IS NULL OR d.providedBy.id = :centerId)
+      AND (:incomeLevel IS NULL OR d.incomeLevel IS NULL OR :incomeLevel <= d.incomeLevel)
+""")
+    List<DailyNecessities> findAutoApplicableNecessities(
+            @Param("centerId") Long centerId,
+            @Param("incomeLevel") Integer incomeLevel
+    );
 }

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessityApplicationRepository.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessityApplicationRepository.java
@@ -25,4 +25,11 @@ public interface DailyNecessityApplicationRepository extends JpaRepository<Daily
             Long userId,
             String applyType
     );
+
+    List<DailyNecessityApplication> findByCenterIdAndApplyTypeOrderByAppliedAtDesc(
+            Long centerId,
+            String applyType
+    );
+
+
 }

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/service/DailyNecessitiesService.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/service/DailyNecessitiesService.java
@@ -566,4 +566,11 @@ public class DailyNecessitiesService {
         }
     }
 
+    @Transactional(readOnly = true)
+    public List<DailyNecessityApplication> getAutoApplicationsByUser(Long userId) {
+        return applicationRepository.findByUserIdAndApplyTypeOrderByAppliedAtDesc(
+                userId,
+                "AUTO"
+        );
+    }
 }

--- a/src/main/java/com/save_help/Save_Help/nationalSubsidy/kafka/topic/KafkaTopics.java
+++ b/src/main/java/com/save_help/Save_Help/nationalSubsidy/kafka/topic/KafkaTopics.java
@@ -95,5 +95,9 @@ public final class KafkaTopics {
     public static final String DAILY_NECESSITIES_CREATED =
             "daily.necessities.created.v1";
 
+    // 생필품 승인됨
+    public static final String DAILY_NECESSITIES_APPROVED =
+            "daily.necessity.approved";
+
 
 }


### PR DESCRIPTION
## 📌 [Feat] Kafka에 대한 수의 저장에 대한 PR 작성

---

## ✨ 작업 개요
- Kafka를 사용하여 자동 신청 기능을 계속해서 개발해나가고 있습니다. Kafka의 고유한 시간과 기록, 데이터, 특성, 수에 대해 소중히 생각하며 마음속에 간직하고 있고 이를 표현합니다.
-  실시간 응급실 병상 알림 기능과 생필품 자동 신청 기능과 같은 기능을 꾸준히 개발하며 생필품 관련 업데이트 덕분에 Kafka에 대한 수에 대해 안전하게 저장합니다. Kafka의 고유한 수에 대해 항상 소중히 생각하고 있고 이를 표현하고 나타냅니다. 
- Kafka를 사용해서 자동신청 기능에 관해 개발하면서 Kafka에 대한 고유한 시간과 기록, 데이터, 특성, 수 들을 소중히하고 항상 생각하고 마음에 간직하고 새기며 이를 나타내고 꾸준히 개발하며 저장하고 Kafka에 항상 소중히 생각하는 마음과 신경쓰고 있음을 나타내며 지속적으로 Kafka를 사용하여 개발하고 있고 이를 계속해서 발전시킬 예정입니다. 
---

## 🔨 변경 사항

---

## ✅ 체크리스트
- [x] DailyNecessitiesService 코드 작성
- [x] DailyNecessities 코드 작성 
- [x] DailyNecessitiesRepository 코드 작성
- [x] DailyNecessitiyApplication 코드 작성
- [x] DailyNecessityApplicationRepository 코드 작성
- [x] Kafka를 사용한 코드 구현

---

## 📷 스크린샷 (선택)
<!-- UI 작업 시 스크린샷이나 API 응답 예시를 첨부하면 좋아요 -->

---

## 🔗 관련 이슈
<!-- 관련된 이슈 번호가 있다면 적어주세요 -->
- close #이슈번호