### PR TITLE
[Feat] Kafka를 통한 생필품 자동 신청 서비스 개발 및 PR 작성

### DIFF
--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessities.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessities.java
@@ -162,4 +162,7 @@ public class DailyNecessities {
                 && isWithinApplyPeriod();
     }
 
+    public String getAutoApplyReason() {
+        return "생필품 자동 신청 조건 충족: " + this.name;
+    }
 }

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessityApplication.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessityApplication.java
@@ -59,4 +59,8 @@ public class DailyNecessityApplication {
     public boolean isPending() {
         return "PENDING".equals(this.status);
     }
+
+    public void approve() {
+        this.status = "APPROVED";
+    }
 }

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesRepository.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesRepository.java
@@ -153,4 +153,17 @@ public interface DailyNecessitiesRepository extends JpaRepository<DailyNecessiti
             @Param("centerId") Long centerId,
             @Param("incomeLevel") Integer incomeLevel
     );
+
+    @Query("""
+    SELECT d
+    FROM DailyNecessities d
+    WHERE d.id = :necessityId
+      AND d.active = true
+      AND d.approvalStatus = com.save_help.Save_Help.dailyNecessities.entity.DailyNecessities.ApprovalStatus.APPROVED
+      AND d.stock > 0
+""")
+    Optional<DailyNecessities> findAutoApplicableNecessity(
+            @Param("necessityId") Long necessityId
+    );
+
 }

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessityApplicationRepository.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessityApplicationRepository.java
@@ -31,5 +31,10 @@ public interface DailyNecessityApplicationRepository extends JpaRepository<Daily
             String applyType
     );
 
+    // 자동 신청, 상태별 조회
+    List<DailyNecessityApplication> findByApplyTypeAndStatusOrderByAppliedAtDesc(
+            String applyType,
+            String status
+    );
 
 }

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/service/DailyNecessitiesService.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/service/DailyNecessitiesService.java
@@ -573,4 +573,12 @@ public class DailyNecessitiesService {
                 "AUTO"
         );
     }
+
+    @Transactional(readOnly = true)
+    public List<DailyNecessityApplication> getPendingAutoApplications() {
+        return applicationRepository.findByApplyTypeAndStatusOrderByAppliedAtDesc(
+                "AUTO",
+                "PENDING"
+        );
+    }
 }

--- a/src/main/java/com/save_help/Save_Help/nationalSubsidy/kafka/topic/KafkaTopics.java
+++ b/src/main/java/com/save_help/Save_Help/nationalSubsidy/kafka/topic/KafkaTopics.java
@@ -99,5 +99,7 @@ public final class KafkaTopics {
     public static final String DAILY_NECESSITIES_APPROVED =
             "daily.necessity.approved";
 
-
+    // 자동신청 성공
+    public static final String DAILY_NECESSITIES_AUTO_APPLY_SUCCESS =
+            "necessity.auto.apply.success";
 }


### PR DESCRIPTION
## 📌 [Feat] Kafka를 통한 생필품 자동 신청 서비스 개발 및 PR 작성

---

## ✨ 작업 개요
- Kafka를 사용하여 생필품 자동 신청 기능을 개발하고 있습니다. Kafka를 완전하게 소중히 생각하며 항상 신경쓰고 마음속에 간직하고 있고 항상 생각하고 있습니다.
-  실시간 응급실 병상 알림 기능과 생필품 자동 신청 기능과 같은 기능을 꾸준히 개발하며 언제 커밋을 올려야하는지 잘하고 있는게 맞는지 혹시 틀린부분이 없는지 이 날짜에 표현을 해도 괜찮은지 잘 몰라서 걱정이 됐었는데 Kafka의 카운팅 기능과 직관적인 세부사항을 보고 알 수 있어서 걱정을 덜 수 있었습니다. 이에 Kafka에 감사함을 나타내고 앞으로도 지속적으로 피드백과 세부사항을 면밀히 수용하여 커밋을 올릴 예정입니다. 
- Kafka를 사용해서 자동신청 기능에 관해 개발하면서 Kafka에 대한 모든것들을 소중히하고 항상 생각하고 마음에 간직하고 새기며 개발하고 감사한 생필품 관련 업데이트를 통해 안심하고 개발할 수 있었습니다. 기능들을 계속해서 꾸준히 개발하며 Kafka를 항상 소중히 생각하는 마음이있고 Kafka의 모든 것들을 완전하게 아끼고 있습니다. 그리고 이러한 마음을 바탕으로 지속적으로 Kafka를 사용하여 개발하고 있고 이를 계속해서 발전시킬 예정입니다. 
---

## 🔨 변경 사항

---

## ✅ 체크리스트
- [x] DailyNecessitiesService 코드 작성
- [x] DailyNecessities 코드 작성 
- [x] DailyNecessitiesRepository 코드 작성
- [x] DailyNecessitiyApplication 코드 작성
- [x] DailyNecessityApplicationRepository 코드 작성
- [x] Kafka를 사용한 코드 구현

---

## 📷 스크린샷 (선택)
<!-- UI 작업 시 스크린샷이나 API 응답 예시를 첨부하면 좋아요 -->

---

## 🔗 관련 이슈
<!-- 관련된 이슈 번호가 있다면 적어주세요 -->
- close #이슈번호