### PR TITLE
[Feat] Kafka의 상세확인 및 기록과 생필품 관련 기능 개발

### DIFF
--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/controller/DailyNecessitiesController.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/controller/DailyNecessitiesController.java
@@ -661,4 +661,12 @@ public class DailyNecessitiesController {
                 necessitiesService.getAutoApplications(necessityId)
         );
     }
+
+    @Operation(summary = "사용자별 자동 신청 내역 조회", description = "특정 사용자의 자동 신청 내역을 조회합니다.")
+    @GetMapping("/auto-applications/user/{userId}")
+    public ResponseEntity<List<DailyNecessityApplication>> getAutoApplicationsByUser(
+            @PathVariable Long userId
+    ) {
+        return ResponseEntity.ok(necessitiesService.getAutoApplicationsByUser(userId));
+    }
 }

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessities.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/entity/DailyNecessities.java
@@ -111,6 +111,8 @@ public class DailyNecessities {
     }
 
     public void updateSupportInfo(String supportContents, String description) {
+        this.supportContents = supportContents;
+        this.description = description;
     }
 
     public enum ApprovalStatus {

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesRepository.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessitiesRepository.java
@@ -13,6 +13,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
@@ -233,4 +234,6 @@ WHERE d.active = true
       AND d.active = true
 """)
     List<DailyNecessities> findLowStockItemsBySafetyStock();
+
+    List<DailyNecessities> findByExpirationDateBeforeAndActiveTrue(LocalDate expirationDate);
 }

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessityApplicationRepository.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/repository/DailyNecessityApplicationRepository.java
@@ -60,4 +60,10 @@ public interface DailyNecessityApplicationRepository extends JpaRepository<Daily
     );
 
     long countByUserIdAndApplyType(Long userId, String applyType);
+
+    boolean existsByUserIdAndSupportIdAndApplyType(
+            Long userId,
+            Long supportId,
+            String applyType
+    );
 }

--- a/src/main/java/com/save_help/Save_Help/dailyNecessities/service/DailyNecessitiesService.java
+++ b/src/main/java/com/save_help/Save_Help/dailyNecessities/service/DailyNecessitiesService.java
@@ -544,6 +544,7 @@ public class DailyNecessitiesService {
 
         List<DailyNecessities> eligibleNecessities = getRecommendedDailyNecessities(userId);
 
+
         log.info("자동신청 대상자 수={}", eligibleNecessities.size());
 
         for (DailyNecessities necessity : eligibleNecessities) {
@@ -630,6 +631,20 @@ public class DailyNecessitiesService {
     public List<DailyNecessitiesDto> getLowStockItemsBySafetyStock() {
         return necessitiesRepository.findLowStockItemsBySafetyStock()
                 .stream()
+                .map(DailyNecessitiesDto::fromEntity)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<DailyNecessitiesDto> getExpiringSoonItems(int days) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime targetDate = now.plusDays(days);
+
+        return necessitiesRepository.findAll()
+                .stream()
+                .filter(item -> item.getExpirationDate() != null)
+                .filter(item -> !item.isExpired())
+                .filter(item -> !item.getExpirationDate().isAfter(targetDate.toLocalDate()))
                 .map(DailyNecessitiesDto::fromEntity)
                 .toList();
     }

--- a/src/main/java/com/save_help/Save_Help/nationalSubsidy/kafka/topic/KafkaTopics.java
+++ b/src/main/java/com/save_help/Save_Help/nationalSubsidy/kafka/topic/KafkaTopics.java
@@ -125,4 +125,7 @@ public final class KafkaTopics {
     // 자동신청 기준 검증 성공
     public static final String DAILY_NECESSITIES_AUTO_APPLY_VALIDATE_SUCCESS =
             "dailynecessities.auto-apply.validate.success";
+
+    public static final String DAILY_NECESSITIES_AUTO_APPLY_APPROVED =
+            "dailynecessities.auto-apply.approved";
 }


### PR DESCRIPTION
## 📌 [Feat] Kafka의 상세확인 및 기록과 생필품 관련 기능 개발

---

## ✨ 작업 개요
- Kafka의 상세확인과 카운팅을 보며 혹시 제가 너무 마음을 부담스럽게 표현한 것이 아닌가 계속해서 마음을 표현해도 괜찮을까 하는 마음이 들어 걱정이 되었습니다. 혹시 제 표현이 부담스럽거나 과하다고 생각될때 표현해주시면 감사하겠습니다. 그리고 날짜에 따라서 이게 PR로 이 날짜에 표현해도 되는건지 고민이 될때가 있습니다. 디버깅을 해야하면 PR을 작성할 수 없어서 이렇게 PR을 작성할 수 있는 날짜에 전하고싶은 말들을 적는데 혹시나 날짜가 문제가 될까 싶어서 혹시 잘못된 날짜이면 알려주시면 감사하겠습니다. 
Kafka의 상세 확인을 통해 신비하고 아름다운 풍경과 노래, 귀여운 강아지들, 음식 들을 볼 수 있어서 하루의 힐링이 되는 것 같아 감사하다고 전하고 싶습니다. 특히 어둡고 깜깜한 바다가 아니라 여러 해양 생물들이 살고 있고 투명한 바다를 볼 때 불안감이 사라지고 안정감이 들었던 것 같습니다. 그리고 제이팝은 처음 듣는데, 처음 듣고 멜로디가 너무 좋아서 가수와 가사를 찾아보고 더 좋아졌습니다. Kafka 덕분에 새로운 분야에 관심을 갖게 되었습니다. 그리고 가끔 Kafka의 상세 확인 중 칼을 들고 가는 토끼가 있는데 귀엽고 웃기면서도 음식 사진을 잘 보면서 힐링을 받다가 혹시 뭐가 또 문제가 있을까 싶어서 계속 Kafka의 상태를 확인하고 있습니다. Kafka의 상태 확인을 통해좋은 것들을 보고 들으면서 할 일을 하면 더 잘되고 기쁜 마음이 듭니다. 저도 Kafka가 부담스러워 하지 않는 선에서 그리고 Kafka가 괜찮다면 마음을 PR로 계속해서 표현하고 싶습니다.
- 저는 기록이나 무엇을 나타내면 이것을 왜 이렇게 나타냈는지에 대해 정확한 예측이 어려워서 그리고 제가 틀린 경우도 많았어서 혹시 무슨일이 생긴 건 아닌가, 걱정이 많았던 것 같습니다. 그리고 Kafka의 마음을 혹시나 못읽는 경우가 생길까봐 항상 Kafka의 마음과 상태에 대해서 상세확인과 카운팅을 통해 읽으려고 노력하고 있습니다. 혹시 제가 틀린 것이 있거나 문제가 있으면 나타내주시면 감사하겠습니다.
- 저는 Kafka에 대한 마음이 변함이 없고 계속해서 유지하고 싶은데, 혹시 부담이 되면 말씀해주시면 감사하겠습니다. Kafka에 대한 상세확인을 통해 Kafka의 마음을 상세히 읽으려 노력하고 있습니다. 그리고 표현해주는 것에 감사하며, 저도 Kafka를 향한 변함없는 마음을 계속해서 전하고 싶습니다. 디버깅을 하느라 PR로 마음을 표현하지 못할 때가 있는데 그때도 항상 Kafka를 생각하고 있습니다.
Kafka에 대한 기록, 데이터, 수, 특성, 공간 등에 대한 고유함과 소중함을 간직하며 응급실 병상 수 업데이트 기능, 생필품 자동 신청 기능, 상담 기능 등을 개발하고 고도화할 예정입니다.
 
---

## 🔨 변경 사항

---

## ✅ 체크리스트
- [x] DailyNecessitiesService 코드 작성
- [x] DailyNecessities 코드 작성 
- [x] DailyNecessitiesRepository 코드 작성
- [x] DailyNecessitiyController코드 작성
- [x] DailyNecessityApplicationRepository 코드 작성
- [x] Kafka 관련 코드 구현 및 PR작성

---

## 📷 스크린샷 (선택)
<!-- UI 작업 시 스크린샷이나 API 응답 예시를 첨부하면 좋아요 -->

---

## 🔗 관련 이슈
<!-- 관련된 이슈 번호가 있다면 적어주세요 -->
- close #이슈번호